### PR TITLE
Updates to Apple pass generation

### DIFF
--- a/config/mobile-pass.php
+++ b/config/mobile-pass.php
@@ -1,5 +1,17 @@
 <?php
 
+use Spatie\LaravelMobilePass\Actions\Apple\NotifyAppleOfPassUpdateAction;
+use Spatie\LaravelMobilePass\Actions\Apple\RegisterDeviceAction;
+use Spatie\LaravelMobilePass\Actions\Apple\UnregisterDeviceAction;
+use Spatie\LaravelMobilePass\Builders\Apple\AirlinePassBuilder;
+use Spatie\LaravelMobilePass\Builders\Apple\BoardingPassBuilder;
+use Spatie\LaravelMobilePass\Builders\Apple\CouponPassBuilder;
+use Spatie\LaravelMobilePass\Builders\Apple\GenericPassBuilder;
+use Spatie\LaravelMobilePass\Builders\Apple\StoreCardPassBuilder;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassDevice;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassRegistration;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
 return [
     /*
     * Read the "Getting credentials from Apple" section in the documentation
@@ -28,9 +40,9 @@ return [
     * by creating your own action class that extend the one that ships with the package.
     */
     'actions' => [
-        'notify_apple_of_pass_update' => Spatie\LaravelMobilePass\Actions\Apple\NotifyAppleOfPassUpdateAction::class,
-        'register_device' => Spatie\LaravelMobilePass\Actions\Apple\RegisterDeviceAction::class,
-        'unregister_device' => Spatie\LaravelMobilePass\Actions\Apple\UnregisterDeviceAction::class,
+        'notify_apple_of_pass_update' => NotifyAppleOfPassUpdateAction::class,
+        'register_device' => RegisterDeviceAction::class,
+        'unregister_device' => UnregisterDeviceAction::class,
     ],
 
     /*
@@ -38,9 +50,9 @@ return [
     * your own models by extending the ones that ship with the package.
     */
     'models' => [
-        'mobile_pass' => Spatie\LaravelMobilePass\Models\MobilePass::class,
-        'apple_mobile_pass_registration' => Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassRegistration::class,
-        'apple_mobile_pass_device' => Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassDevice::class,
+        'mobile_pass' => MobilePass::class,
+        'apple_mobile_pass_registration' => AppleMobilePassRegistration::class,
+        'apple_mobile_pass_device' => AppleMobilePassDevice::class,
     ],
 
     /*
@@ -48,11 +60,11 @@ return [
     */
     'builders' => [
         'apple' => [
-            'airline' => Spatie\LaravelMobilePass\Builders\Apple\AirlinePassBuilder::class,
-            'boarding' => Spatie\LaravelMobilePass\Builders\Apple\BoardingPassBuilder::class,
-            'coupon' => Spatie\LaravelMobilePass\Builders\Apple\CouponPassBuilder::class,
-            'generic' => Spatie\LaravelMobilePass\Builders\Apple\GenericPassBuilder::class,
-            'store_card' => Spatie\LaravelMobilePass\Builders\Apple\StoreCardPassBuilder::class,
+            'airline' => AirlinePassBuilder::class,
+            'boarding' => BoardingPassBuilder::class,
+            'coupon' => CouponPassBuilder::class,
+            'generic' => GenericPassBuilder::class,
+            'store_card' => StoreCardPassBuilder::class,
         ],
     ],
 ];

--- a/database/migrations/create_mobile_pass_tables.php.stub
+++ b/database/migrations/create_mobile_pass_tables.php.stub
@@ -34,7 +34,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
 
             $table->string('device_id');
-            $table->foreign('device_id')->references('id')->on('mobile_pass_devices');
+            $table->foreign('device_id')->references('id')->on('apple_mobile_pass_devices');
 
             $table->string('pass_type_id');
             $table->uuid('pass_serial');

--- a/docs/basic-usage/generating-your-first-pass.md
+++ b/docs/basic-usage/generating-your-first-pass.md
@@ -5,7 +5,7 @@ weight: 3
 
 The package offers [various builder classes](TODO: add link) that you can use to build passes.  These builders all have specialized methods to build their specific passes.
 
-Here's an example of how you can generate a basic boarding pass:
+Here's an example of how you can generate a basic airline boarding pass:
 
 ```php
 use Spatie\LaravelMobilePass\Builders\Apple\AirlinePassBuilder;

--- a/docs/basic-usage/generating-your-first-pass.md
+++ b/docs/basic-usage/generating-your-first-pass.md
@@ -9,6 +9,9 @@ Here's an example of how you can generate a basic boarding pass:
 
 ```php
 use Spatie\LaravelMobilePass\Builders\Apple\AirlinePassBuilder;
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\FieldContent;
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Image;
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Seat;
 
 $mobilePass = AirlinePassBuilder::make()
     ->setOrganisationName('My organisation')
@@ -48,7 +51,7 @@ $mobilePass = AirlinePassBuilder::make()
     )
     ->setIconImage(
         Image::make(
-            x1Path: getTestSupportPath('images/your-thumbnail.png')
+            x1Path: public_path('images/your-thumbnail.png')
         )
     )
 

--- a/src/Actions/Apple/RegisterDeviceAction.php
+++ b/src/Actions/Apple/RegisterDeviceAction.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelMobilePass\Actions\Apple;
 
 use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassDevice;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassRegistration;
 use Spatie\LaravelMobilePass\Models\MobilePass;
 use Spatie\LaravelMobilePass\Support\Config;
 
@@ -13,7 +14,7 @@ class RegisterDeviceAction
         string $pushToken,
         string $passTypeId,
         string $passSerial,
-    ) {
+    ): AppleMobilePassRegistration {
         $pass = $this->mobilePass($passSerial);
 
         $device = $this->device($deviceId, $pushToken);
@@ -29,14 +30,14 @@ class RegisterDeviceAction
     {
         $mobilePassModel = Config::mobilePassModel();
 
-        return $mobilePassModel::findOrFail($passSerial);
+        return $mobilePassModel::query()->findOrFail($passSerial);
     }
 
     protected function device(string $deviceId, string $pushToken): AppleMobilePassDevice
     {
         $mobilePassDeviceModel = Config::appleDeviceModel();
 
-        return $mobilePassDeviceModel::updateOrCreate(
+        return $mobilePassDeviceModel::query()->updateOrCreate(
             ['id' => $deviceId],
             ['push_token' => $pushToken],
         );

--- a/src/Actions/Apple/UnregisterDeviceAction.php
+++ b/src/Actions/Apple/UnregisterDeviceAction.php
@@ -7,7 +7,7 @@ use Spatie\LaravelMobilePass\Support\Config;
 
 class UnregisterDeviceAction
 {
-    public function execute(string $deviceId, string $passSerial)
+    public function execute(string $deviceId, string $passSerial): void
     {
         $mobilePassRegistrationModel = Config::appleMobilePassRegistrationModel();
 

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -186,6 +186,27 @@ abstract class ApplePassBuilder
         return $this;
     }
 
+    public function setBackgroundColour(Colour $backgroundColour): self
+    {
+        $this->backgroundColour = $backgroundColour;
+
+        return $this;
+    }
+
+    public function setForegroundColour(Colour $foregroundColour): self
+    {
+        $this->foregroundColour = $foregroundColour;
+
+        return $this;
+    }
+
+    public function setLabelColour(Colour $labelColour): self
+    {
+        $this->labelColour = $labelColour;
+
+        return $this;
+    }
+
     /**
      * The total price for the pass.
      */
@@ -334,6 +355,9 @@ abstract class ApplePassBuilder
             'teamIdentifier' => config('mobile-pass.apple.team_identifier'),
             'description' => $this->description,
             'semantics' => $this->compileSemantics(),
+            'backgroundColor' => (string) $this->backgroundColour,
+            'foregroundColor' => (string) $this->foregroundColour,
+            'labelColor' => (string) $this->labelColour,
             'userInfo' => [
                 'passType' => $this->type->value,
             ],

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -142,7 +142,7 @@ abstract class ApplePassBuilder
         return $this;
     }
 
-    public function updateField(string $key, Closure $fieldContent)
+    public function updateField(string $key, Closure $fieldContent): self
     {
         $fieldTypes = [
             'headerFields',
@@ -266,7 +266,7 @@ abstract class ApplePassBuilder
             return $this->model;
         }
 
-        return MobilePass::create([
+        return MobilePass::query()->create([
             'type' => $this->type->value,
             'platform' => static::platform(),
             'builder_name' => static::name(),
@@ -301,7 +301,7 @@ abstract class ApplePassBuilder
         return $data;
     }
 
-    public function generate()
+    public function generate(): string
     {
         $pkPass = new PKPass(
             self::getCertificatePath(),
@@ -340,7 +340,7 @@ abstract class ApplePassBuilder
         ]));
     }
 
-    protected function uncompileSemantics()
+    protected function uncompileSemantics(): void
     {
         $this->totalPrice = ! empty($this->data['semantics']['totalPrice']) ? Price::fromArray($this->data['semantics']['totalPrice']) : null;
         $this->wifiDetails = ! empty($this->data['semantics']['wifiAccess']) ? collect(

--- a/src/Builders/Apple/BoardingPassBuilder.php
+++ b/src/Builders/Apple/BoardingPassBuilder.php
@@ -101,7 +101,7 @@ abstract class BoardingPassBuilder extends ApplePassBuilder
     /**
      * A booking or reservation confirmation number.
      */
-    public function setConfirmationNumber(string $confirmationNumber)
+    public function setConfirmationNumber(string $confirmationNumber): self
     {
         $this->confirmationNumber = $confirmationNumber;
 
@@ -355,7 +355,7 @@ abstract class BoardingPassBuilder extends ApplePassBuilder
         return $this;
     }
 
-    protected function uncompileSemantics()
+    protected function uncompileSemantics(): void
     {
         parent::uncompileSemantics();
 

--- a/src/Builders/Apple/CouponPassBuilder.php
+++ b/src/Builders/Apple/CouponPassBuilder.php
@@ -21,10 +21,10 @@ class CouponPassBuilder extends ApplePassBuilder
             parent::compileData(),
             [
                 'coupon' => array_filter([
-                    'primaryFields' => $this->primaryFields?->toArray(),
-                    'secondaryFields' => $this->secondaryFields?->toArray(),
-                    'headerFields' => $this->headerFields?->toArray(),
-                    'auxiliaryFields' => $this->auxiliaryFields?->toArray(),
+                    'primaryFields' => $this->primaryFields?->values()->toArray(),
+                    'secondaryFields' => $this->secondaryFields?->values()->toArray(),
+                    'headerFields' => $this->headerFields?->values()->toArray(),
+                    'auxiliaryFields' => $this->auxiliaryFields?->values()->toArray(),
                 ]),
             ],
         );

--- a/src/Builders/Apple/Entities/Location.php
+++ b/src/Builders/Apple/Entities/Location.php
@@ -21,7 +21,7 @@ class Location implements Arrayable
         );
     }
 
-    public static function fromArray(array $values)
+    public static function fromArray(array $values): self
     {
         return new self(
             latitude: $values['latitude'],

--- a/src/Exceptions/InvalidConfig.php
+++ b/src/Exceptions/InvalidConfig.php
@@ -7,7 +7,7 @@ use Spatie\LaravelMobilePass\Enums\Platform;
 
 class InvalidConfig extends Exception
 {
-    public static function invalidModel($modelName, $modelClass, $defaultClass): self
+    public static function invalidModel(string $modelName, string $modelClass, string $defaultClass): self
     {
         return new static("The `{$modelName}` model must be an instance of `{$defaultClass}`. `{$modelClass}` does not extend {$defaultClass}.");
     }
@@ -22,17 +22,17 @@ class InvalidConfig extends Exception
         return new static("The `{$eventName}` event must be an instance of `{$shouldBeOrExtend}`. `{$eventClass}` does not extend {$shouldBeOrExtend}.");
     }
 
-    public static function passBuilderNotRegistered(string $passBuilderName, Platform $platform)
+    public static function passBuilderNotRegistered(string $passBuilderName, Platform $platform): self
     {
         return new static("The pass builder `{$passBuilderName}` is not registered. Make sure you have registered it in the `builders.{$platform->value}` key of the  `mobile-pass` config file.");
     }
 
-    public static function passBuilderNotFound(string $passBuilderName, mixed $passBuilderClass)
+    public static function passBuilderNotFound(string $passBuilderName, mixed $passBuilderClass): self
     {
         return new static("The pass builder `{$passBuilderName}` was not found. Make sure the class `{$passBuilderClass}` exists.");
     }
 
-    public static function invalidPassBuilderClass(string $passBuilderName, mixed $passBuilderClass, Platform $platform)
+    public static function invalidPassBuilderClass(string $passBuilderName, mixed $passBuilderClass, Platform $platform): self
     {
         $expectedNamespace = match ($platform) {
             Platform::Apple => 'Spatie\LaravelMobilePass\Builders\Apple',

--- a/src/Exceptions/PlatformDoesntSupport.php
+++ b/src/Exceptions/PlatformDoesntSupport.php
@@ -7,7 +7,7 @@ use Spatie\LaravelMobilePass\Enums\Platform;
 
 class PlatformDoesntSupport extends Exception
 {
-    public static function cannotDownload(Platform $platform)
+    public static function cannotDownload(Platform $platform): self
     {
         return new static("Platform {$platform->value} doesn't support downloading passes.");
     }

--- a/src/Models/MobilePass.php
+++ b/src/Models/MobilePass.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Http\Response;
 use Illuminate\Mail\Attachment;
 use Illuminate\Support\Str;
 use Spatie\LaravelMobilePass\Actions\Apple\NotifyAppleOfPassUpdateAction;
@@ -27,7 +28,7 @@ class MobilePass extends Model implements Attachable, Responsable
 
     public $guarded = [];
 
-    public static function boot()
+    public static function boot(): void
     {
         parent::boot();
 
@@ -54,7 +55,7 @@ class MobilePass extends Model implements Attachable, Responsable
         return $this->hasManyThrough($deviceModelClass, $modelClass, 'pass_serial', 'id', 'id', 'device_id');
     }
 
-    protected function casts()
+    protected function casts(): array
     {
         return [
             'platform' => Platform::class,
@@ -100,12 +101,12 @@ class MobilePass extends Model implements Attachable, Responsable
         return $this->updated_at > $since;
     }
 
-    public function toResponse($request)
+    public function toResponse($request): Response
     {
         return $this->download($this->download_name)->toResponse($request);
     }
 
-    public function toMailAttachment()
+    public function toMailAttachment(): Attachment
     {
         return Attachment::fromData(fn () => $this->generate(), $this->downloadName().'.pkpass')
             ->withMime('application/vnd.apple.pkpass');

--- a/src/Support/Apple/DownloadableMobilePass.php
+++ b/src/Support/Apple/DownloadableMobilePass.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelMobilePass\Support\Apple;
 
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 
 class DownloadableMobilePass implements Responsable
@@ -14,7 +15,7 @@ class DownloadableMobilePass implements Responsable
         $this->downloadName = Str::beforeLast($this->downloadName, '.pkpass');
     }
 
-    protected function headers()
+    protected function headers(): array
     {
         return [
             'Content-Type' => 'application/vnd.apple.pkpass',
@@ -22,7 +23,7 @@ class DownloadableMobilePass implements Responsable
         ];
     }
 
-    public function toResponse($request)
+    public function toResponse($request): Response
     {
         return response($this->passContent)->withHeaders($this->headers());
     }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -12,19 +12,19 @@ use Spatie\LaravelMobilePass\Models\MobilePass;
 
 class Config
 {
-    /** @return class-string<\Spatie\LaravelMobilePass\Models\MobilePass> */
+    /** @return class-string<MobilePass> */
     public static function mobilePassModel(): string
     {
         return self::getModelClass('mobile_pass', MobilePass::class);
     }
 
-    /** @return class-string<\Spatie\LaravelMobilePass\Models\MobilePass> */
+    /** @return class-string<MobilePass> */
     public static function appleMobilePassRegistrationModel(): string
     {
         return self::getModelClass('apple_mobile_pass_registration', AppleMobilePassRegistration::class);
     }
 
-    /** @return class-string<\Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassDevice> */
+    /** @return class-string<AppleMobilePassDevice> */
     public static function appleDeviceModel(): string
     {
         return self::getModelClass('apple_mobile_pass_device', AppleMobilePassDevice::class);
@@ -56,7 +56,7 @@ class Config
         return $actionClass;
     }
 
-    /** @return class-string<\Spatie\LaravelMobilePass\Builders\Apple\ApplePassBuilder|\Spatie\LaravelMobilePass\Builders\Google\GooglePassBuilder> */
+    /** @return class-string<ApplePassBuilder|GooglePassBuilder> */
     public static function getPassBuilderClass(string $passBuilderName, Platform $platform): string
     {
         $passBuilderClass = config("mobile-pass.builders.{$platform->value}.{$passBuilderName}");

--- a/tests/Builders/BuildMobilePassTest.php
+++ b/tests/Builders/BuildMobilePassTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelMobilePass\Tests\Feature;
 
+use Illuminate\Validation\ValidationException;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\FieldContent;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Image;
 use Spatie\LaravelMobilePass\Builders\Apple\GenericPassBuilder;
@@ -48,6 +49,13 @@ it('can create a mobile pass', function () {
 
     expect($passkeyContent)->toMatchMobilePassSnapshot();
 });
+
+it('throws a validation exception when a required field is missing', function () {
+    GenericPassBuilder::make()
+        ->setSerialNumber(123456)
+        // description intentionally omitted
+        ->data();
+})->throws(ValidationException::class);
 
 it('updates a field', function () {
     $pass = GenericPassBuilder::make()


### PR DESCRIPTION
- Fixes a bug where the migration incorrectly referenced the wrong table name
- Updates the documentation for generating an Apple pass to include required `use` statements
- Adds missing return types
- Adds the ability to set background colour, foreground colour and label colour to passes
- Fixes a bug where Coupon passes would fail to compile due to incorrect compilation of fields (needs `->values()`)