### PR TITLE
Fix: emit backFields for StoreCard and Coupon passes

### DIFF
--- a/src/Builders/Apple/CouponPassBuilder.php
+++ b/src/Builders/Apple/CouponPassBuilder.php
@@ -25,6 +25,7 @@ class CouponPassBuilder extends ApplePassBuilder
                     'secondaryFields' => $this->secondaryFields?->values()->toArray(),
                     'headerFields' => $this->headerFields?->values()->toArray(),
                     'auxiliaryFields' => $this->auxiliaryFields?->values()->toArray(),
+                    'backFields' => $this->backFields?->values()->toArray(),
                 ]),
             ],
         );

--- a/src/Builders/Apple/GenericPassBuilder.php
+++ b/src/Builders/Apple/GenericPassBuilder.php
@@ -25,6 +25,7 @@ class GenericPassBuilder extends ApplePassBuilder
                     'secondaryFields' => $this->secondaryFields?->values()->toArray(),
                     'headerFields' => $this->headerFields?->values()->toArray(),
                     'auxiliaryFields' => $this->auxiliaryFields?->values()->toArray(),
+                    'backFields' => $this->backFields?->values()->toArray(),
                 ]),
             ],
         );

--- a/src/Builders/Apple/StoreCardPassBuilder.php
+++ b/src/Builders/Apple/StoreCardPassBuilder.php
@@ -25,6 +25,7 @@ class StoreCardPassBuilder extends ApplePassBuilder
                     'secondaryFields' => $this->secondaryFields?->values()->toArray(),
                     'headerFields' => $this->headerFields?->values()->toArray(),
                     'auxiliaryFields' => $this->auxiliaryFields?->values()->toArray(),
+                    'backFields' => $this->backFields?->values()->toArray(),
                 ]),
             ],
         );

--- a/tests/Builders/Apple/CouponPassBuilderTest.php
+++ b/tests/Builders/Apple/CouponPassBuilderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\CouponPassBuilder;
+
+it('compiles back fields into the coupon payload', function () {
+    $compiledData = CouponPassBuilder::make()
+        ->setOrganizationName('My organization')
+        ->setSerialNumber(123456)
+        ->setDescription('Hello!')
+        ->addBackField('terms', 'Terms and conditions apply.')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($compiledData)->toHaveKey('coupon');
+    expect($compiledData['coupon'])->toHaveKey('backFields');
+    expect($compiledData['coupon']['backFields'])->toHaveCount(1);
+    expect($compiledData['coupon']['backFields'][0])->toMatchArray([
+        'key' => 'terms',
+        'value' => 'Terms and conditions apply.',
+    ]);
+});
+
+it('has a name', function () {
+    expect(CouponPassBuilder::name())->toBe('coupon');
+});

--- a/tests/Builders/Apple/GenericPassBuilderTest.php
+++ b/tests/Builders/Apple/GenericPassBuilderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\GenericPassBuilder;
+
+it('compiles back fields into the generic payload', function () {
+    $compiledData = GenericPassBuilder::make()
+        ->setOrganizationName('My organization')
+        ->setSerialNumber(123456)
+        ->setDescription('Hello!')
+        ->addBackField('terms', 'Terms and conditions apply.')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($compiledData)->toHaveKey('generic');
+    expect($compiledData['generic'])->toHaveKey('backFields');
+    expect($compiledData['generic']['backFields'])->toHaveCount(1);
+    expect($compiledData['generic']['backFields'][0])->toMatchArray([
+        'key' => 'terms',
+        'value' => 'Terms and conditions apply.',
+    ]);
+});
+
+it('has a name', function () {
+    expect(GenericPassBuilder::name())->toBe('generic');
+});

--- a/tests/Builders/Apple/StoreCardPassBuilderTest.php
+++ b/tests/Builders/Apple/StoreCardPassBuilderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\StoreCardPassBuilder;
+
+it('compiles back fields into the store card payload', function () {
+    $compiledData = StoreCardPassBuilder::make()
+        ->setOrganizationName('My organization')
+        ->setSerialNumber(123456)
+        ->setDescription('Hello!')
+        ->addBackField('terms', 'Terms and conditions apply.')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($compiledData)->toHaveKey('storeCard');
+    expect($compiledData['storeCard'])->toHaveKey('backFields');
+    expect($compiledData['storeCard']['backFields'])->toHaveCount(1);
+    expect($compiledData['storeCard']['backFields'][0])->toMatchArray([
+        'key' => 'terms',
+        'value' => 'Terms and conditions apply.',
+    ]);
+});
+
+it('has a name', function () {
+    expect(StoreCardPassBuilder::name())->toBe('store_card');
+});


### PR DESCRIPTION
Fix: Emit backFields for StoreCard and Coupon pass types

StoreCardPassBuilder and CouponPassBuilder were storing back fields internally
but never emitting them into the compiled pass payload.

This PR adds backFields to the compiled storeCard and coupon data, bringing them
in line with EventTicketPassBuilder and the Apple Wallet specification.