### PR TITLE
Update EventTicketPassBuilder.php

### DIFF
--- a/src/Builders/Google/EventTicketPassBuilder.php
+++ b/src/Builders/Google/EventTicketPassBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelMobilePass\Builders\Google;
 
+use Spatie\LaravelMobilePass\Builders\Google\Entities\LocalizedString;
 use Spatie\LaravelMobilePass\Builders\Google\Validators\EventTicketObjectValidator;
 use Spatie\LaravelMobilePass\Builders\Google\Validators\GooglePassObjectValidator;
 use Spatie\LaravelMobilePass\Enums\PassType;
@@ -12,11 +13,11 @@ class EventTicketPassBuilder extends GooglePassBuilder
 
     protected ?string $attendeeName = null;
 
-    protected ?string $section = null;
+    protected ?LocalizedString $section = null;
 
-    protected ?string $row = null;
+    protected ?LocalizedString $row = null;
 
-    protected ?string $seat = null;
+    protected ?LocalizedString $seat = null;
 
     protected static function validator(): GooglePassObjectValidator
     {
@@ -40,12 +41,13 @@ class EventTicketPassBuilder extends GooglePassBuilder
         return $this;
     }
 
-    public function setSection(string $section): self
+    public function setSection(string $section, string $language = 'en-US'): self
     {
-        $this->section = $section;
-
+        $this->section = LocalizedString::of($section, $language);
+        
         return $this;
     }
+
 
     public function setRow(string $row): self
     {
@@ -65,10 +67,11 @@ class EventTicketPassBuilder extends GooglePassBuilder
     protected function compileData(): array
     {
         $seatInfo = $this->filterEmpty([
-            'section' => $this->section,
-            'row' => $this->row,
-            'seat' => $this->seat,
+            'section' => $this->section?->toArray(),
+            'row' => $this->row?->toArray(),
+            'seat' => $this->seat?->toArray(),
         ]);
+
 
         return $this->filterEmpty([
             'ticketHolderName' => $this->attendeeName,

--- a/src/Builders/Google/EventTicketPassBuilder.php
+++ b/src/Builders/Google/EventTicketPassBuilder.php
@@ -44,21 +44,20 @@ class EventTicketPassBuilder extends GooglePassBuilder
     public function setSection(string $section, string $language = 'en-US'): self
     {
         $this->section = LocalizedString::of($section, $language);
-        
-        return $this;
-    }
-
-
-    public function setRow(string $row): self
-    {
-        $this->row = $row;
 
         return $this;
     }
 
-    public function setSeat(string $seat): self
+    public function setRow(string $row, string $language = 'en-US'): self
     {
-        $this->seat = $seat;
+        $this->row = LocalizedString::of($row, $language);
+
+        return $this;
+    }
+
+    public function setSeat(string $seat, string $language = 'en-US'): self
+    {
+        $this->seat = LocalizedString::of($seat, $language);
 
         return $this;
     }
@@ -71,7 +70,6 @@ class EventTicketPassBuilder extends GooglePassBuilder
             'row' => $this->row?->toArray(),
             'seat' => $this->seat?->toArray(),
         ]);
-
 
         return $this->filterEmpty([
             'ticketHolderName' => $this->attendeeName,

--- a/tests/Builders/Google/EventTicketPassBuilderTest.php
+++ b/tests/Builders/Google/EventTicketPassBuilderTest.php
@@ -35,9 +35,9 @@ it('creates a MobilePass row and POSTs the object to Google', function () {
         expect($request['classId'])->toBe('3388.ts-2026');
         expect($request['id'])->toBe('3388.john');
         expect($request['ticketHolderName'])->toBe('John Smith');
-        expect($request['seatInfo']['section'])->toBe('B12');
-        expect($request['seatInfo']['row'])->toBe('8');
-        expect($request['seatInfo']['seat'])->toBe('22');
+        expect($request['seatInfo']['section'])->toBe(['defaultValue' => ['language' => 'en-US', 'value' => 'B12']]);
+        expect($request['seatInfo']['row'])->toBe(['defaultValue' => ['language' => 'en-US', 'value' => '8']]);
+        expect($request['seatInfo']['seat'])->toBe(['defaultValue' => ['language' => 'en-US', 'value' => '22']]);
         expect($request['barcode']['type'])->toBe('QR_CODE');
         expect($request['barcode']['value'])->toBe('TS-JS');
 


### PR DESCRIPTION
SeatInfo sent as plain strings EventTicketPassBuilder stored section, row, seat as ?string, then dropped them straight into the payload:

$seatInfo = $this->filterEmpty([
    'section' => $this->section,   // "Floor A"
    'row' => $this->row,            // "12"
    'seat' => $this->seat,          // "24"
]);

But Google Wallet's EventTicketObject.seatInfo schema requires each field to be a LocalizedString.