### PR TITLE
Fix #28: hash certificate contents in cached temp filename

### DIFF
--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -420,7 +420,9 @@ abstract class ApplePassBuilder
             return self::appleConfig('certificate_path');
         }
 
-        $path = sys_get_temp_dir().'/LaravelMobilePass.p12';
+        $hash = md5($contents);
+
+        $path = sys_get_temp_dir()."/LaravelMobilePass-{$hash}.p12";
 
         if (file_exists($path)) {
             return $path;

--- a/tests/Builders/Apple/CertificatePathTest.php
+++ b/tests/Builders/Apple/CertificatePathTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\CouponPassBuilder;
+
+afterEach(function () {
+    foreach (glob(sys_get_temp_dir().'/LaravelMobilePass-*.p12') as $file) {
+        @unlink($file);
+    }
+});
+
+it('returns the configured certificate path when no inline certificate is set', function () {
+    config()->set('mobile-pass.apple.certificate', null);
+    config()->set('mobile-pass.apple.certificate_path', '/path/to/cert.p12');
+
+    expect(CouponPassBuilder::getCertificatePath())->toBe('/path/to/cert.p12');
+});
+
+it('writes a base64-encoded certificate to a hashed temp path', function () {
+    $contents = base64_encode('certificate-contents');
+    config()->set('mobile-pass.apple.certificate', $contents);
+
+    $path = CouponPassBuilder::getCertificatePath();
+
+    expect($path)->toBe(sys_get_temp_dir().'/LaravelMobilePass-'.md5($contents).'.p12')
+        ->and(file_exists($path))->toBeTrue()
+        ->and(file_get_contents($path))->toBe('certificate-contents');
+});
+
+it('writes a new file when the certificate is rotated', function () {
+    $first = base64_encode('first-certificate');
+    config()->set('mobile-pass.apple.certificate', $first);
+
+    $firstPath = CouponPassBuilder::getCertificatePath();
+
+    $second = base64_encode('second-certificate');
+    config()->set('mobile-pass.apple.certificate', $second);
+
+    $secondPath = CouponPassBuilder::getCertificatePath();
+
+    expect($secondPath)->not->toBe($firstPath)
+        ->and(file_get_contents($secondPath))->toBe('second-certificate')
+        ->and(file_get_contents($firstPath))->toBe('first-certificate');
+});


### PR DESCRIPTION
Fixes #28

The Apple certificate cached from `MOBILE_PASS_APPLE_CERTIFICATE` was always written to `/tmp/LaravelMobilePass.p12`. Once that file existed, a rotated env var would never replace it, so the new key was silently ignored unless the cached file was removed manually.

## Changes

- Include an md5 hash of the base64 contents in the cached filename (`LaravelMobilePass-{hash}.p12`), so rotating the env var automatically writes to a new path.
- Add tests covering the path-based config, the inline cert path, and the rotation case.

## Notes

- On upgrade the previous cached file becomes orphaned; the next request just writes the certificate once under the new name, so the cost is negligible. Per the issue author's suggestion.