### PR TITLE
Fix #32: route Apple webservice lookups by serial_number

### DIFF
--- a/database/factories/AppleMobilePassRegistrationFactory.php
+++ b/database/factories/AppleMobilePassRegistrationFactory.php
@@ -16,7 +16,7 @@ class AppleMobilePassRegistrationFactory extends Factory
         return [
             'device_id' => AppleMobilePassDevice::factory(),
             'pass_type_id' => 'pass.com.example',
-            'pass_serial' => MobilePass::factory(),
+            'pass_serial' => fn () => MobilePass::factory()->create()->serial_number,
         ];
     }
 }

--- a/database/factories/MobilePassFactory.php
+++ b/database/factories/MobilePassFactory.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelMobilePass\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Image;
 use Spatie\LaravelMobilePass\Enums\Platform;
 use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassDevice;
@@ -15,7 +16,10 @@ class MobilePassFactory extends Factory
 
     public function definition(): array
     {
+        $serialNumber = (string) Str::uuid();
+
         return [
+            'serial_number' => $serialNumber,
             'builder_name' => 'generic',
             'type' => 'generic',
             'platform' => Platform::Apple,
@@ -29,7 +33,7 @@ class MobilePassFactory extends Factory
                 'webServiceURL' => '/passkit/',
                 'teamIdentifier' => '2SQU7LWHMY',
                 'description' => 'Laravel Exclusive Coupon',
-                'serialNumber' => '0195cd4a-9f78-717f-b397-59cad6b78a27',
+                'serialNumber' => $serialNumber,
                 'backgroundColor' => 'rgb(81, 35, 20)',
                 'foregroundColor' => 'rgb(255, 134, 41)',
                 'labelColor' => 'rgb(245, 235, 220)',

--- a/database/migrations/add_serial_number_to_mobile_passes.php.stub
+++ b/database/migrations/add_serial_number_to_mobile_passes.php.stub
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('mobile_passes', function (Blueprint $table) {
+            $table->string('serial_number')->nullable()->after('id');
+        });
+
+        DB::table('mobile_passes')
+            ->whereNull('serial_number')
+            ->update(['serial_number' => DB::raw('id')]);
+
+        Schema::table('mobile_passes', function (Blueprint $table) {
+            $table->string('serial_number')->nullable(false)->change();
+            $table->unique('serial_number');
+        });
+
+        Schema::table('apple_mobile_pass_registrations', function (Blueprint $table) {
+            $table->dropForeign(['pass_serial']);
+            $table->string('pass_serial')->change();
+            $table->foreign('pass_serial')->references('serial_number')->on('mobile_passes');
+        });
+    }
+};

--- a/database/migrations/create_mobile_pass_tables.php.stub
+++ b/database/migrations/create_mobile_pass_tables.php.stub
@@ -11,6 +11,8 @@ return new class extends Migration
         Schema::create('mobile_passes', function (Blueprint $table) {
             $table->uuid('id')->primary();
 
+            $table->string('serial_number')->unique();
+
             $table->string('type');
             $table->string('platform');
             $table->string('builder_name');
@@ -38,8 +40,8 @@ return new class extends Migration
 
             $table->string('pass_type_id');
 
-            $table->foreignUuid('pass_serial')
-                ->constrained('mobile_passes', 'id');
+            $table->string('pass_serial');
+            $table->foreign('pass_serial')->references('serial_number')->on('mobile_passes');
 
             $table->timestamps();
 

--- a/src/Actions/Apple/RegisterDeviceAction.php
+++ b/src/Actions/Apple/RegisterDeviceAction.php
@@ -36,7 +36,9 @@ class RegisterDeviceAction
     {
         $mobilePassModel = Config::mobilePassModel();
 
-        return $mobilePassModel::query()->findOrFail($passSerial);
+        return $mobilePassModel::query()
+            ->where('serial_number', $passSerial)
+            ->firstOrFail();
     }
 
     protected function device(string $deviceId, string $pushToken): AppleMobilePassDevice

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -441,6 +441,8 @@ abstract class ApplePassBuilder
     public function save(): MobilePass
     {
         if ($this->model) {
+            $this->serialNumber = $this->model->serial_number;
+
             $this->model->update([
                 'content' => $this->data(),
                 'images' => $this->images,
@@ -450,7 +452,12 @@ abstract class ApplePassBuilder
             return $this->model;
         }
 
+        if (empty($this->serialNumber)) {
+            $this->serialNumber = (string) Str::uuid();
+        }
+
         return MobilePass::query()->create([
+            'serial_number' => $this->serialNumber,
             'type' => $this->type->value,
             'platform' => static::platform(),
             'builder_name' => static::name(),

--- a/src/Builders/Google/GooglePassBuilder.php
+++ b/src/Builders/Google/GooglePassBuilder.php
@@ -125,6 +125,7 @@ abstract class GooglePassBuilder
         $mobilePassClass = Config::mobilePassModel();
 
         return $mobilePassClass::query()->create([
+            'serial_number' => $this->objectId(),
             'type' => $this->type->value,
             'platform' => Platform::Google,
             'builder_name' => static::name(),

--- a/src/Http/Requests/Apple/CheckForUpdatesRequest.php
+++ b/src/Http/Requests/Apple/CheckForUpdatesRequest.php
@@ -10,7 +10,9 @@ class CheckForUpdatesRequest extends FormRequest
 {
     public function mobilePass(): MobilePass
     {
-        return MobilePass::findOrFail($this->route('passSerial'));
+        return MobilePass::query()
+            ->where('serial_number', $this->route('passSerial'))
+            ->firstOrFail();
     }
 
     public function lastModifiedSinceHeaderValue(): ?Carbon

--- a/src/MobilePassServiceProvider.php
+++ b/src/MobilePassServiceProvider.php
@@ -15,7 +15,10 @@ class MobilePassServiceProvider extends PackageServiceProvider
             ->name('laravel-mobile-pass')
             ->hasConfigFile()
             ->hasRoutes('mobile-pass')
-            ->hasMigration('create_mobile_pass_tables');
+            ->hasMigrations([
+                'create_mobile_pass_tables',
+                'add_serial_number_to_mobile_passes',
+            ]);
     }
 
     public function registeringPackage(): void

--- a/src/Models/Apple/AppleMobilePassRegistration.php
+++ b/src/Models/Apple/AppleMobilePassRegistration.php
@@ -25,7 +25,7 @@ class AppleMobilePassRegistration extends Model
 
     public function pass(): BelongsTo
     {
-        return $this->belongsTo(Config::mobilePassModel(), 'pass_serial');
+        return $this->belongsTo(Config::mobilePassModel(), 'pass_serial', 'serial_number');
     }
 
     public function device(): BelongsTo

--- a/src/Models/MobilePass.php
+++ b/src/Models/MobilePass.php
@@ -29,6 +29,7 @@ use Spatie\LaravelMobilePass\Support\Google\GoogleJwtSigner;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
+ * @property string $serial_number
  * @property string $builder_name
  * @property Platform $platform
  * @property array $images
@@ -68,7 +69,7 @@ class MobilePass extends Model implements Attachable, Responsable
     {
         $modelClass = Config::appleMobilePassRegistrationModel();
 
-        return $this->hasMany($modelClass, 'pass_serial');
+        return $this->hasMany($modelClass, 'pass_serial', 'serial_number');
     }
 
     public function devices(): HasManyThrough
@@ -76,7 +77,7 @@ class MobilePass extends Model implements Attachable, Responsable
         $modelClass = Config::appleMobilePassRegistrationModel();
         $deviceModelClass = Config::appleDeviceModel();
 
-        return $this->hasManyThrough($deviceModelClass, $modelClass, 'pass_serial', 'id', 'id', 'device_id');
+        return $this->hasManyThrough($deviceModelClass, $modelClass, 'pass_serial', 'id', 'serial_number', 'device_id');
     }
 
     /** @return HasMany<GoogleMobilePassEvent, $this> */

--- a/tests/Http/Controllers/CheckForUpdatesControllerTest.php
+++ b/tests/Http/Controllers/CheckForUpdatesControllerTest.php
@@ -11,7 +11,7 @@ it('returns the generated pass when no If-Modified-Since header is passed', func
     $this
         ->withoutMiddleware()
         ->getJson(route('mobile-pass.check-for-updates', [
-            'passSerial' => $pass->getKey(),
+            'passSerial' => $pass->serial_number,
             'passTypeId' => 'pass.com.example',
         ]))
         ->assertSuccessful();
@@ -26,7 +26,7 @@ it('returns the generated pass if pass was updated after given time', function (
             'If-Modified-Since' => now()->subMinutes(5)->toRfc7231String(),
         ])
         ->getJson(route('mobile-pass.check-for-updates', [
-            'passSerial' => $pass->getKey(),
+            'passSerial' => $pass->serial_number,
             'passTypeId' => 'pass.com.example',
         ]))
         ->assertSuccessful();
@@ -41,7 +41,7 @@ it('returns 304 if pass was not updated after given time', function () {
             'If-Modified-Since' => $pass->updated_at->toRfc7231String(),
         ])
         ->getJson(route('mobile-pass.check-for-updates', [
-            'passSerial' => $pass->getKey(),
+            'passSerial' => $pass->serial_number,
             'passTypeId' => 'pass.com.example',
         ]))
         ->assertNotModified();
@@ -58,7 +58,7 @@ it('doesnt trigger an update to Apple', function () {
     $this
         ->withoutMiddleware()
         ->getJson(route('mobile-pass.check-for-updates', [
-            'passSerial' => $pass->getKey(),
+            'passSerial' => $pass->serial_number,
             'passTypeId' => 'pass.com.example',
         ]))
         ->assertSuccessful();

--- a/tests/Http/Controllers/CustomSerialNumberFlowTest.php
+++ b/tests/Http/Controllers/CustomSerialNumberFlowTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Tests\Http;
+
+use Spatie\LaravelMobilePass\Builders\Apple\CouponPassBuilder;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassRegistration;
+
+it('lets Apple register, list, look up, and unregister a pass that uses a custom non-UUID serial', function () {
+    $customSerial = 'BTL-SHEA-0042';
+
+    $pass = CouponPassBuilder::make()
+        ->setOrganizationName('Acme')
+        ->setDescription('Boston Tea Leaves Loyalty')
+        ->setSerialNumber($customSerial)
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->save();
+
+    expect($pass->serial_number)->toBe($customSerial);
+    expect($pass->content['serialNumber'])->toBe($customSerial);
+
+    // Apple registers the device for this serial
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.register-device', [
+            'passSerial' => $customSerial,
+            'deviceId' => 'device-1',
+            'passTypeId' => 'pass.com.example',
+        ]), ['pushToken' => 'token-1'])
+        ->assertCreated();
+
+    $this->assertModelExists(AppleMobilePassRegistration::class, [
+        'device_id' => 'device-1',
+        'pass_serial' => $customSerial,
+        'pass_type_id' => 'pass.com.example',
+    ]);
+
+    // Apple asks for the list of serials it should poll for updates
+    $this
+        ->withoutMiddleware()
+        ->getJson(route('mobile-pass.get-associated-serials-for-device', [
+            'deviceId' => 'device-1',
+            'passTypeId' => 'pass.com.example',
+        ]))
+        ->assertSuccessful()
+        ->assertJson(['serialNumbers' => [$customSerial]]);
+
+    // Apple checks for an updated pass using the serial it received above
+    $this
+        ->withoutMiddleware()
+        ->getJson(route('mobile-pass.check-for-updates', [
+            'passSerial' => $customSerial,
+            'passTypeId' => 'pass.com.example',
+        ]))
+        ->assertSuccessful();
+
+    // Apple unregisters the device for this serial
+    $this
+        ->withoutMiddleware()
+        ->deleteJson(route('mobile-pass.unregister-device', [
+            'passSerial' => $customSerial,
+            'deviceId' => 'device-1',
+            'passTypeId' => 'pass.com.example',
+        ]))
+        ->assertSuccessful();
+
+    expect(AppleMobilePassRegistration::count())->toBe(0);
+});
+
+it('falls back to a UUID serial when none is set', function () {
+    $pass = CouponPassBuilder::make()
+        ->setOrganizationName('Acme')
+        ->setDescription('Default-serial Coupon')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->save();
+
+    expect($pass->serial_number)->toBe($pass->content['serialNumber']);
+
+    $this
+        ->withoutMiddleware()
+        ->getJson(route('mobile-pass.check-for-updates', [
+            'passSerial' => $pass->serial_number,
+            'passTypeId' => 'pass.com.example',
+        ]))
+        ->assertSuccessful();
+});

--- a/tests/Http/Controllers/GetAssociatedSerialsForDeviceControllerTest.php
+++ b/tests/Http/Controllers/GetAssociatedSerialsForDeviceControllerTest.php
@@ -22,7 +22,7 @@ it('returns pass serials associated with a device', function () {
         ->assertSuccessful()
         ->assertJson([
             'serialNumbers' => [
-                $registration->pass->getKey(),
+                $registration->pass->serial_number,
             ],
         ]);
 });
@@ -71,7 +71,7 @@ it('only returns passes that have been updated since the given timestamp', funct
         ->assertSuccessful()
         ->assertJson([
             'serialNumbers' => [
-                $secondPass->getKey(),
+                $secondPass->serial_number,
             ],
         ]);
 });

--- a/tests/Http/Controllers/RegisterDeviceControllerTest.php
+++ b/tests/Http/Controllers/RegisterDeviceControllerTest.php
@@ -15,7 +15,7 @@ it('stores the registration', function () {
     $this
         ->withoutMiddleware()
         ->postJson(route('mobile-pass.register-device', [
-            'passSerial' => $pass->getKey(),
+            'passSerial' => $pass->serial_number,
             'deviceId' => '12345',
             'passTypeId' => 'pass.com.example',
         ]), [
@@ -25,13 +25,13 @@ it('stores the registration', function () {
 
     $this->assertModelExists(AppleMobilePassDevice::class, [
         'device_id' => '12345',
-        'pass_serial' => $pass->getKey(),
+        'pass_serial' => $pass->serial_number,
         'push_token' => '12345',
     ]);
 
     $this->assertModelExists(AppleMobilePassRegistration::class, [
         'device_id' => '12345',
-        'pass_serial' => $pass->getKey(),
+        'pass_serial' => $pass->serial_number,
         'pass_type_id' => 'pass.com.example',
     ]);
 });
@@ -47,7 +47,7 @@ it('doesnt trigger a change notification to Apple', function () {
     $this
         ->withoutMiddleware()
         ->postJson(route('mobile-pass.register-device', [
-            'passSerial' => $pass->getKey(),
+            'passSerial' => $pass->serial_number,
             'deviceId' => '12345',
             'passTypeId' => 'pass.com.example',
         ]), [
@@ -61,7 +61,7 @@ it('doesnt create duplicate entries for the same device', function () {
     $this
         ->withoutMiddleware()
         ->postJson(route('mobile-pass.register-device', [
-            'passSerial' => $registration->pass->getKey(),
+            'passSerial' => $registration->pass->serial_number,
             'deviceId' => $registration->device->getKey(),
             'passTypeId' => 'pass.com.example',
         ]), [
@@ -81,7 +81,7 @@ it('fires MobilePassAdded when a new registration is created', function () {
     $this
         ->withoutMiddleware()
         ->postJson(route('mobile-pass.register-device', [
-            'passSerial' => $pass->getKey(),
+            'passSerial' => $pass->serial_number,
             'deviceId' => '12345',
             'passTypeId' => 'pass.com.example',
         ]), ['pushToken' => '12345']);
@@ -99,7 +99,7 @@ it('does not fire MobilePassAdded when the same device re-registers', function (
     $this
         ->withoutMiddleware()
         ->postJson(route('mobile-pass.register-device', [
-            'passSerial' => $registration->pass->getKey(),
+            'passSerial' => $registration->pass->serial_number,
             'deviceId' => $registration->device->getKey(),
             'passTypeId' => 'pass.com.example',
         ]), ['pushToken' => '12345']);

--- a/tests/Http/Controllers/UnregisterDeviceControllerTest.php
+++ b/tests/Http/Controllers/UnregisterDeviceControllerTest.php
@@ -13,7 +13,7 @@ it('deletes the registration', function () {
     $this
         ->withoutMiddleware()
         ->deleteJson(route('mobile-pass.unregister-device', [
-            'passSerial' => $registration->pass->getKey(),
+            'passSerial' => $registration->pass->serial_number,
             'deviceId' => $registration->device->getKey(),
             'passTypeId' => $registration->pass_type_id,
         ]))
@@ -28,7 +28,7 @@ it('doesnt delete the device', function () {
     $this
         ->withoutMiddleware()
         ->deleteJson(route('mobile-pass.unregister-device', [
-            'passSerial' => $registration->pass->getKey(),
+            'passSerial' => $registration->pass->serial_number,
             'deviceId' => $registration->device->getKey(),
             'passTypeId' => $registration->pass_type_id,
         ]))
@@ -58,7 +58,7 @@ it('fires MobilePassRemoved when a registration is deleted', function () {
     $this
         ->withoutMiddleware()
         ->deleteJson(route('mobile-pass.unregister-device', [
-            'passSerial' => $registration->pass->getKey(),
+            'passSerial' => $registration->pass->serial_number,
             'deviceId' => $registration->device->getKey(),
             'passTypeId' => $registration->pass_type_id,
         ]));

--- a/tests/Models/MobilePassGoogleEventsTest.php
+++ b/tests/Models/MobilePassGoogleEventsTest.php
@@ -44,7 +44,7 @@ it('isCurrentlySavedToGoogleWallet returns false when there are no events', func
 it('isCurrentlyInWallet is true for Apple passes with at least one registration', function () {
     $pass = MobilePass::factory()->create(['platform' => Platform::Apple]);
 
-    AppleMobilePassRegistration::factory()->create(['pass_serial' => $pass->id]);
+    AppleMobilePassRegistration::factory()->create(['pass_serial' => $pass->serial_number]);
 
     expect($pass->isCurrentlyInWallet())->toBeTrue();
 });


### PR DESCRIPTION
## Summary

Apple's PassKit webservice sends the value of `pass.json.serialNumber` as the `passSerial` route parameter. The package was looking up `MobilePass` records by primary key (`id`), so register / check-for-updates / unregister returned 404 whenever:

- the user called `->setSerialNumber('BTL-SHEA-0042')` (the case in #32, which the docs explicitly demonstrate), or
- nothing was set, because `ApplePassBuilder::data()` then assigned a fresh random UUID for `serialNumber` that did not match the model's auto-generated `id`.

The existing tests masked the bug because they used `$pass->getKey()` for the `passSerial` route param, never exercising what Apple actually sends.

## Approach

- Add a unique `serial_number` column to `mobile_passes`. It mirrors the value baked into the pass file's `serialNumber`.
- Change `apple_mobile_pass_registrations.pass_serial` from a UUID FK on `mobile_passes.id` to a string FK on `mobile_passes.serial_number`. Without this, custom non-UUID serials cannot be stored as registrations.
- Look up by `serial_number` in `CheckForUpdatesRequest`, `RegisterDeviceAction`, and `UnregisterDeviceAction`.
- `ApplePassBuilder::save()` populates `serial_number` from `$this->serialNumber` (defaulting to a UUID when nothing was set). `GooglePassBuilder::save()` populates it from `objectId()`.
- New published migration `add_serial_number_to_mobile_passes` for existing installs: backfills `serial_number` from `id` and rewires the registrations FK.
- New regression test (`CustomSerialNumberFlowTest`) round-trips a non-UUID custom serial through register → list → check-for-updates → unregister.

## Breaking change

This is a 2.0 candidate, not a patch:

- Existing installs must publish and run the new migration.
- `MobilePass::registrations()` now keys on `serial_number`. Custom queries joining `mobile_passes.id` to `apple_mobile_pass_registrations.pass_serial` will return empty results until updated.
- `apple_mobile_pass_registrations.pass_serial` column type changes from `uuid` to `string`.
- `AppleMobilePassRegistrationFactory` no longer accepts a `MobilePass` factory directly for `pass_serial`; pass `$pass->serial_number` instead.

Anyone who used the documented `->setSerialNumber(...)` API was already broken, so for them this is purely a fix.

## Verification

- `vendor/bin/pint --dirty` clean
- `composer analyse` clean
- `vendor/bin/pest` 199 passed (including the new end-to-end regression for custom serials)

Fixes #32