### PR TITLE
add reverse relationship for MobilePass model

### DIFF
--- a/src/Models/MobilePass.php
+++ b/src/Models/MobilePass.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Mail\Attachment;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
@@ -61,6 +62,12 @@ class MobilePass extends Model implements Attachable, Responsable
 
             PushPassUpdateJob::dispatch($mobilePass, $action);
         });
+    }
+
+    /** @return MorphTo<Model, $this> */
+    public function model(): MorphTo
+    {
+        return $this->morphTo();
     }
 
     /** @return HasMany<AppleMobilePassRegistration, $this> */

--- a/tests/Models/Concerns/HasMobilePassesTest.php
+++ b/tests/Models/Concerns/HasMobilePassesTest.php
@@ -90,3 +90,12 @@ it('narrows firstApplePass and firstGooglePass by pass type', function () {
     expect($this->testModel->refresh()->firstApplePass(PassType::Generic))->not()->toBeNull();
     expect($this->testModel->refresh()->firstApplePass(PassType::BoardingPass))->toBeNull();
 });
+
+it('can get the reverse relationship', function () {
+    $mobilePass = MobilePass::factory()->create();
+    $this->testModel->addMobilePass($mobilePass);
+
+    expect($mobilePass->model?->id)
+        ->not->toBeNull()
+        ->toEqual($this->testModel->id);
+});


### PR DESCRIPTION
Adds the `model()` relationship to the `MobilePass` model (reverse of the trait `mobilePasses()` relationship)