### PR TITLE
Add  = 'string' so apple device can resolve id.

### DIFF
--- a/src/Models/Apple/AppleMobilePassDevice.php
+++ b/src/Models/Apple/AppleMobilePassDevice.php
@@ -18,6 +18,8 @@ class AppleMobilePassDevice extends Model
 
     public $incrementing = false;
 
+    public $keyType = 'string';
+
     public function registrations(): HasMany
     {
         return $this->hasMany(Config::appleMobilePassRegistrationModel(), 'device_id');


### PR DESCRIPTION
## Summary

Adds the missing $keyType = 'string' declaration to AppleMobilePassDevice so Eloquent treats the primary key as a string.

## Why

The apple_mobile_pass_devices table is created with a string primary key:

```php
Schema::create('apple_mobile_pass_devices', function (Blueprint $table) {
      $table->string('id')->primary();
      // ...
  });
```

The model already disables auto-incrementing (`public $incrementing = false`), but without `$keyType = 'string'` Eloquent still defaults to an integer key and casts the value accordingly. This breaks `RegisterDeviceAction::device()`, where `updateOrCreate(['id' => $deviceId], ...)` is called with the arbitrary string identifier Apple sends in the device-registration callback — the string gets cast to int, and either no record is found or a wrong row is matched.