### PR TITLE
Respect the configured mobile pass model throughout the package

### DIFF
--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -25,6 +25,7 @@ use Spatie\LaravelMobilePass\Enums\TimeStyleType;
 use Spatie\LaravelMobilePass\Exceptions\InvalidCertificate;
 use Spatie\LaravelMobilePass\Exceptions\InvalidConfig;
 use Spatie\LaravelMobilePass\Models\MobilePass;
+use Spatie\LaravelMobilePass\Support\Config;
 use Spatie\LaravelMobilePass\Support\WifiUri;
 
 /**
@@ -498,7 +499,9 @@ abstract class ApplePassBuilder
 
         $content = $this->data();
 
-        return MobilePass::query()->create([
+        $mobilePassClass = Config::mobilePassModel();
+
+        return $mobilePassClass::query()->create([
             'pass_serial' => $this->serialNumber,
             'type' => $this->type->value,
             'platform' => static::platform(),

--- a/src/Http/Requests/Apple/CheckForUpdatesRequest.php
+++ b/src/Http/Requests/Apple/CheckForUpdatesRequest.php
@@ -5,12 +5,15 @@ namespace Spatie\LaravelMobilePass\Http\Requests\Apple;
 use Carbon\Carbon;
 use Illuminate\Foundation\Http\FormRequest;
 use Spatie\LaravelMobilePass\Models\MobilePass;
+use Spatie\LaravelMobilePass\Support\Config;
 
 class CheckForUpdatesRequest extends FormRequest
 {
     public function mobilePass(): MobilePass
     {
-        return MobilePass::query()
+        $mobilePassClass = Config::mobilePassModel();
+
+        return $mobilePassClass::query()
             ->where('pass_serial', $this->route('passSerial'))
             ->firstOrFail();
     }

--- a/tests/Models/ConfiguredMobilePassModelTest.php
+++ b/tests/Models/ConfiguredMobilePassModelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Tests\Models;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\LaravelMobilePass\Builders\Apple\GenericPassBuilder;
+use Spatie\LaravelMobilePass\Tests\TestSupport\Models\CustomMobilePass;
+
+beforeEach(function () {
+    Schema::create('custom_mobile_passes', function (Blueprint $table) {
+        $table->uuid('id')->primary();
+        $table->string('pass_serial')->unique();
+        $table->string('type');
+        $table->string('platform');
+        $table->string('builder_name');
+        $table->json('content');
+        $table->json('images');
+        $table->string('download_name')->nullable();
+        $table->nullableMorphs('model');
+        $table->timestamp('expired_at')->nullable();
+        $table->timestamps();
+    });
+
+    config()->set('mobile-pass.models.mobile_pass', CustomMobilePass::class);
+});
+
+it('saves an Apple pass to the configured mobile pass model', function () {
+    $pass = GenericPassBuilder::make()
+        ->setOrganizationName('Spatie')
+        ->setDescription('Hello!')
+        ->setSerialNumber('custom-serial-123')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->save();
+
+    expect($pass)->toBeInstanceOf(CustomMobilePass::class);
+
+    $this->assertDatabaseHas('custom_mobile_passes', ['pass_serial' => 'custom-serial-123']);
+    $this->assertDatabaseCount('mobile_passes', 0);
+});
+
+it('resolves the configured mobile pass model when checking for updates', function () {
+    $pass = GenericPassBuilder::make()
+        ->setOrganizationName('Spatie')
+        ->setDescription('Hello!')
+        ->setSerialNumber('custom-serial-456')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->save();
+
+    $this
+        ->withoutMiddleware()
+        ->getJson(route('mobile-pass.check-for-updates', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]))
+        ->assertSuccessful();
+});

--- a/tests/TestSupport/Models/CustomMobilePass.php
+++ b/tests/TestSupport/Models/CustomMobilePass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Tests\TestSupport\Models;
+
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+class CustomMobilePass extends MobilePass
+{
+    protected $table = 'custom_mobile_passes';
+}


### PR DESCRIPTION
Fixes #42

The package lets you swap the `mobile_pass` model (and others) through `config/mobile-pass.php`, and resolves them via `Support\Config` almost everywhere. Two runtime paths still referenced the base `MobilePass` model directly, so overriding the model (e.g. to point at a different table) was ignored:

- `ApplePassBuilder::save()` created passes with `MobilePass::query()->create(...)`. This is the case from the issue: generating an Apple pass always wrote to the default `mobile_passes` table. The Google builder already resolves the model through config.
- `CheckForUpdatesRequest::mobilePass()` queried `MobilePass::query()`, so the Apple check-for-updates endpoint could not find passes stored on a custom model.

Both now resolve the model through `Config::mobilePassModel()`, consistent with the rest of the package.

## Changes
- Resolve the configured model in `ApplePassBuilder::save()`
- Resolve the configured model in `CheckForUpdatesRequest::mobilePass()`
- Add tests covering a custom `MobilePass` model (with its own table) for both the builder and the check-for-updates endpoint