### PR TITLE
Add location, link, text and image modules to Google classes

### DIFF
--- a/docs/google-wallet/pass-classes.md
+++ b/docs/google-wallet/pass-classes.md
@@ -54,6 +54,29 @@ $classes = EventTicketPassClass::all();
 
 Both methods return instances with the fields Google sends back hydrated onto them.
 
+## Adding locations, links, and modules
+
+Every Google class type supports a few extra building blocks that show up on the back of the pass: geographic locations, a links module (the "main page URL" and any other URIs), text modules, and image modules. Because these are shared across all class types, the same methods are available on every Class builder.
+
+```php
+EventTicketPassClass::make('beatles-shea-1965')
+    ->setIssuerName('Fab Four Promotions')
+    ->setEventName('The Beatles | Live at Shea')
+    ->addLocation(40.7569, -73.8458)
+    ->addLink('https://fabfour.example.com', 'Official site')
+    ->addLink('tel:+15551234567')
+    ->addTextModule('Doors', 'Doors open at 18:30')
+    ->addImageModule('https://example.com/seating-chart.png', 'seating')
+    ->save();
+```
+
+- `addLocation(float $latitude, float $longitude)` adds a point to the class's `locations`.
+- `addLink(string $uri, ?string $description = null)` adds a URI to the links module. The description is optional.
+- `addTextModule(string $header, string $body, ?string $id = null)` adds a text module.
+- `addImageModule(string $imageUrl, ?string $id = null)` adds an image module. The image must be a hosted URL.
+
+Each method can be called multiple times to add more than one entry. When you fetch a class back with `find()` or `all()`, these are hydrated onto the instance and readable through `getLocations()`, `getLinks()`, `getTextModules()`, and `getImageModules()`.
+
 ## Retiring a class
 
 Google has no hard delete for classes. What you can do is call `retire()`, which flips the class's `reviewStatus` to `REJECTED`. Google will stop promoting it, but every pass you've already issued against it keeps working.

--- a/src/Builders/Google/Entities/ImageModule.php
+++ b/src/Builders/Google/Entities/ImageModule.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Builders\Google\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class ImageModule implements Arrayable
+{
+    public function __construct(
+        public readonly Image $image,
+        public readonly ?string $id = null,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        $payload = ['mainImage' => $this->image->toArray()];
+
+        if ($this->id !== null) {
+            $payload['id'] = $this->id;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Builders/Google/Entities/Link.php
+++ b/src/Builders/Google/Entities/Link.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Builders\Google\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Link implements Arrayable
+{
+    public function __construct(
+        public readonly string $uri,
+        public readonly ?string $description = null,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        $payload = ['uri' => $this->uri];
+
+        if ($this->description !== null) {
+            $payload['description'] = $this->description;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Builders/Google/Entities/Location.php
+++ b/src/Builders/Google/Entities/Location.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Builders\Google\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Location implements Arrayable
+{
+    public function __construct(
+        public readonly float $latitude,
+        public readonly float $longitude,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+        ];
+    }
+}

--- a/src/Builders/Google/Entities/TextModule.php
+++ b/src/Builders/Google/Entities/TextModule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Builders\Google\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class TextModule implements Arrayable
+{
+    public function __construct(
+        public readonly string $header,
+        public readonly string $body,
+        public readonly ?string $id = null,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        $payload = [
+            'header' => $this->header,
+            'body' => $this->body,
+        ];
+
+        if ($this->id !== null) {
+            $payload['id'] = $this->id;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Builders/Google/GooglePassClass.php
+++ b/src/Builders/Google/GooglePassClass.php
@@ -201,12 +201,20 @@ abstract class GooglePassClass
     {
         return $this->filterEmpty([
             'locations' => array_map(fn (Location $location) => $location->toArray(), $this->locations),
-            'linksModuleData' => $this->links === []
-                ? []
-                : ['uris' => array_map(fn (Link $link) => $link->toArray(), $this->links)],
+            'linksModuleData' => $this->compileLinks(),
             'textModulesData' => array_map(fn (TextModule $module) => $module->toArray(), $this->textModules),
             'imageModulesData' => array_map(fn (ImageModule $module) => $module->toArray(), $this->imageModules),
         ]);
+    }
+
+    /** @return array<string, mixed> */
+    protected function compileLinks(): array
+    {
+        if ($this->links === []) {
+            return [];
+        }
+
+        return ['uris' => array_map(fn (Link $link) => $link->toArray(), $this->links)];
     }
 
     /** @param array<string, mixed> $payload */

--- a/src/Builders/Google/GooglePassClass.php
+++ b/src/Builders/Google/GooglePassClass.php
@@ -5,7 +5,11 @@ namespace Spatie\LaravelMobilePass\Builders\Google;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Spatie\LaravelMobilePass\Builders\Google\Entities\Image;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\ImageModule;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\Link;
 use Spatie\LaravelMobilePass\Builders\Google\Entities\LocalizedString;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\Location;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\TextModule;
 use Spatie\LaravelMobilePass\Builders\Google\Validators\GooglePassClassValidator;
 use Spatie\LaravelMobilePass\Exceptions\GoogleWalletRequestFailed;
 use Spatie\LaravelMobilePass\Support\Google\GoogleCredentials;
@@ -21,6 +25,18 @@ abstract class GooglePassClass
     protected ?string $issuerName = null;
 
     protected ?string $backgroundColor = null;
+
+    /** @var array<int, Location> */
+    protected array $locations = [];
+
+    /** @var array<int, Link> */
+    protected array $links = [];
+
+    /** @var array<int, TextModule> */
+    protected array $textModules = [];
+
+    /** @var array<int, ImageModule> */
+    protected array $imageModules = [];
 
     abstract protected static function resourceName(): string;
 
@@ -53,6 +69,58 @@ abstract class GooglePassClass
         return $this;
     }
 
+    public function addLocation(float $latitude, float $longitude): static
+    {
+        $this->locations[] = new Location($latitude, $longitude);
+
+        return $this;
+    }
+
+    public function addLink(string $uri, ?string $description = null): static
+    {
+        $this->links[] = new Link($uri, $description);
+
+        return $this;
+    }
+
+    public function addTextModule(string $header, string $body, ?string $id = null): static
+    {
+        $this->textModules[] = new TextModule($header, $body, $id);
+
+        return $this;
+    }
+
+    public function addImageModule(string $imageUrl, ?string $id = null): static
+    {
+        $this->imageModules[] = new ImageModule(Image::fromUrl($imageUrl), $id);
+
+        return $this;
+    }
+
+    /** @return array<int, Location> */
+    public function getLocations(): array
+    {
+        return $this->locations;
+    }
+
+    /** @return array<int, Link> */
+    public function getLinks(): array
+    {
+        return $this->links;
+    }
+
+    /** @return array<int, TextModule> */
+    public function getTextModules(): array
+    {
+        return $this->textModules;
+    }
+
+    /** @return array<int, ImageModule> */
+    public function getImageModules(): array
+    {
+        return $this->imageModules;
+    }
+
     public function id(): string
     {
         return GoogleCredentials::issuerId().'.'.$this->suffix;
@@ -60,7 +128,9 @@ abstract class GooglePassClass
 
     public function save(): static
     {
-        $payload = static::validator()->validate($this->compileData() + ['id' => $this->id()]);
+        $payload = static::validator()->validate(
+            $this->compileData() + $this->compileModules() + ['id' => $this->id()]
+        );
 
         app(GoogleWalletClient::class)->insertClass(static::resourceName(), $this->id(), $payload);
 
@@ -126,6 +196,19 @@ abstract class GooglePassClass
         return array_filter($payload, fn ($value) => $value !== null && $value !== []);
     }
 
+    /** @return array<string, mixed> */
+    protected function compileModules(): array
+    {
+        return $this->filterEmpty([
+            'locations' => array_map(fn (Location $location) => $location->toArray(), $this->locations),
+            'linksModuleData' => $this->links === []
+                ? []
+                : ['uris' => array_map(fn (Link $link) => $link->toArray(), $this->links)],
+            'textModulesData' => array_map(fn (TextModule $module) => $module->toArray(), $this->textModules),
+            'imageModulesData' => array_map(fn (ImageModule $module) => $module->toArray(), $this->imageModules),
+        ]);
+    }
+
     /** @param array<string, mixed> $payload */
     protected function hydrateCommonFields(array $payload): void
     {
@@ -140,6 +223,72 @@ abstract class GooglePassClass
         if (isset($payload['hexBackgroundColor'])) {
             $this->backgroundColor = (string) $payload['hexBackgroundColor'];
         }
+
+        $this->locations = $this->hydrateLocations($payload);
+        $this->links = $this->hydrateLinks($payload);
+        $this->textModules = $this->hydrateTextModules($payload);
+        $this->imageModules = $this->hydrateImageModules($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, Location>
+     */
+    protected function hydrateLocations(array $payload): array
+    {
+        return array_map(
+            fn (array $location) => new Location(
+                (float) ($location['latitude'] ?? 0),
+                (float) ($location['longitude'] ?? 0),
+            ),
+            $payload['locations'] ?? [],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, Link>
+     */
+    protected function hydrateLinks(array $payload): array
+    {
+        return array_map(
+            fn (array $link) => new Link(
+                (string) ($link['uri'] ?? ''),
+                isset($link['description']) ? (string) $link['description'] : null,
+            ),
+            $payload['linksModuleData']['uris'] ?? [],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, TextModule>
+     */
+    protected function hydrateTextModules(array $payload): array
+    {
+        return array_map(
+            fn (array $module) => new TextModule(
+                (string) ($module['header'] ?? ''),
+                (string) ($module['body'] ?? ''),
+                isset($module['id']) ? (string) $module['id'] : null,
+            ),
+            $payload['textModulesData'] ?? [],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, ImageModule>
+     */
+    protected function hydrateImageModules(array $payload): array
+    {
+        return array_map(
+            fn (array $module) => new ImageModule(
+                Image::fromUrl((string) ($module['mainImage']['sourceUri']['uri'] ?? '')),
+                isset($module['id']) ? (string) $module['id'] : null,
+            ),
+            $payload['imageModulesData'] ?? [],
+        );
     }
 
     /** @param  array<string, mixed>  $payload */

--- a/src/Builders/Google/Validators/GooglePassClassValidator.php
+++ b/src/Builders/Google/Validators/GooglePassClassValidator.php
@@ -15,12 +15,38 @@ abstract class GooglePassClassValidator
      */
     public function validate(array $payload): array
     {
-        $validator = validator($payload, $this->rules());
+        $validator = validator($payload, $this->rules() + $this->moduleRules());
 
         if ($validator->fails()) {
             throw new InvalidPass($validator);
         }
 
         return $validator->validated();
+    }
+
+    /**
+     * Module fields are shared by every Google class type, so they live here
+     * instead of being repeated in each class validator.
+     *
+     * @return array<string, array<int, string>>
+     */
+    protected function moduleRules(): array
+    {
+        return [
+            'locations' => ['nullable', 'array'],
+            'locations.*.latitude' => ['nullable', 'numeric'],
+            'locations.*.longitude' => ['nullable', 'numeric'],
+            'linksModuleData' => ['nullable', 'array'],
+            'linksModuleData.uris' => ['nullable', 'array'],
+            'linksModuleData.uris.*.uri' => ['nullable', 'string'],
+            'linksModuleData.uris.*.description' => ['nullable', 'string'],
+            'textModulesData' => ['nullable', 'array'],
+            'textModulesData.*.header' => ['nullable', 'string'],
+            'textModulesData.*.body' => ['nullable', 'string'],
+            'textModulesData.*.id' => ['nullable', 'string'],
+            'imageModulesData' => ['nullable', 'array'],
+            'imageModulesData.*.mainImage' => ['nullable', 'array'],
+            'imageModulesData.*.id' => ['nullable', 'string'],
+        ];
     }
 }

--- a/tests/Builders/Google/GoogleClassModulesTest.php
+++ b/tests/Builders/Google/GoogleClassModulesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Spatie\LaravelMobilePass\Builders\Google\GenericPassClass;
+use Spatie\LaravelMobilePass\Builders\Google\LoyaltyPassClass;
+use Spatie\LaravelMobilePass\Tests\TestSupport\Google\GoogleFixtures;
+
+beforeEach(function () {
+    config()->set('mobile-pass.google.service_account_key_path', GoogleFixtures::serviceAccountPath());
+    config()->set('mobile-pass.google.issuer_id', '3388');
+    config()->set('mobile-pass.google.api_base_url', 'https://example.com/walletobjects/v1');
+    cache()->put('mobile-pass.google.access-token', 'test-token', 3600);
+});
+
+it('sends location, link, text and image modules to Google', function () {
+    Http::fake(['*/genericClass' => Http::response([], 200)]);
+
+    GenericPassClass::make('membership')
+        ->setIssuerName('Spatie')
+        ->addLocation(37.424015, -122.09259)
+        ->addLink('https://spatie.be', 'Visit our site')
+        ->addLink('tel:+3232001212')
+        ->addTextModule('Opening hours', 'Mon to Fri, 9 to 5', 'hours')
+        ->addImageModule('https://cdn.example.com/promo.png', 'promo')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request['locations'][0]['latitude'])->toBe(37.424015);
+        expect($request['locations'][0]['longitude'])->toBe(-122.09259);
+
+        expect($request['linksModuleData']['uris'][0]['uri'])->toBe('https://spatie.be');
+        expect($request['linksModuleData']['uris'][0]['description'])->toBe('Visit our site');
+        expect($request['linksModuleData']['uris'][1]['uri'])->toBe('tel:+3232001212');
+        expect($request['linksModuleData']['uris'][1])->not->toHaveKey('description');
+
+        expect($request['textModulesData'][0]['header'])->toBe('Opening hours');
+        expect($request['textModulesData'][0]['body'])->toBe('Mon to Fri, 9 to 5');
+        expect($request['textModulesData'][0]['id'])->toBe('hours');
+
+        expect($request['imageModulesData'][0]['mainImage']['sourceUri']['uri'])->toBe('https://cdn.example.com/promo.png');
+        expect($request['imageModulesData'][0]['id'])->toBe('promo');
+
+        return true;
+    });
+});
+
+it('omits the module keys entirely when none are set', function () {
+    Http::fake(['*/genericClass' => Http::response([], 200)]);
+
+    GenericPassClass::make('membership')->setIssuerName('Spatie')->save();
+
+    Http::assertSent(function ($request) {
+        expect($request->data())->not->toHaveKey('locations');
+        expect($request->data())->not->toHaveKey('linksModuleData');
+        expect($request->data())->not->toHaveKey('textModulesData');
+        expect($request->data())->not->toHaveKey('imageModulesData');
+
+        return true;
+    });
+});
+
+it('exposes the same module builders on every class type', function () {
+    Http::fake(['*/loyaltyClass' => Http::response([], 200)]);
+
+    LoyaltyPassClass::make('coffee')
+        ->setIssuerName('Spatie')
+        ->setProgramName('Coffee Club')
+        ->addTextModule('Perks', 'Every 10th coffee is free')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request['textModulesData'][0]['header'])->toBe('Perks');
+        expect($request['textModulesData'][0]['body'])->toBe('Every 10th coffee is free');
+        expect($request['textModulesData'][0])->not->toHaveKey('id');
+
+        return true;
+    });
+});
+
+it('hydrates module data back from Google', function () {
+    Http::fake(['*/genericClass/3388.membership' => Http::response([
+        'id' => '3388.membership',
+        'locations' => [['latitude' => 37.424015, 'longitude' => -122.09259]],
+        'linksModuleData' => ['uris' => [['uri' => 'https://spatie.be', 'description' => 'Visit our site']]],
+        'textModulesData' => [['header' => 'Opening hours', 'body' => 'Mon to Fri, 9 to 5', 'id' => 'hours']],
+        'imageModulesData' => [['mainImage' => ['sourceUri' => ['uri' => 'https://cdn.example.com/promo.png']], 'id' => 'promo']],
+    ], 200)]);
+
+    $class = GenericPassClass::find('membership');
+
+    expect($class->getLocations()[0]->latitude)->toBe(37.424015);
+    expect($class->getLocations()[0]->longitude)->toBe(-122.09259);
+    expect($class->getLinks()[0]->uri)->toBe('https://spatie.be');
+    expect($class->getLinks()[0]->description)->toBe('Visit our site');
+    expect($class->getTextModules()[0]->header)->toBe('Opening hours');
+    expect($class->getTextModules()[0]->body)->toBe('Mon to Fri, 9 to 5');
+    expect($class->getTextModules()[0]->id)->toBe('hours');
+    expect($class->getImageModules()[0]->image->publicUrl())->toBe('https://cdn.example.com/promo.png');
+    expect($class->getImageModules()[0]->id)->toBe('promo');
+});


### PR DESCRIPTION
Closes #47

## What

Google Wallet classes expose several shared building blocks in the [Google Pay & Wallet console](https://pay.google.com/business/console) that weren't yet supported by the package: geographic locations, the links module (the "main page URL" and any other URIs), text modules, and image modules.

This adds them to the `GooglePassClass` base, so the new methods are available on **every** class type (`GenericPassClass`, `LoyaltyPassClass`, `OfferPassClass`, `EventTicketPassClass`, `BoardingPassClass`):

```php
EventTicketPassClass::make('beatles-shea-1965')
    ->setIssuerName('Fab Four Promotions')
    ->setEventName('The Beatles | Live at Shea')
    ->addLocation(40.7569, -73.8458)
    ->addLink('https://fabfour.example.com', 'Official site')
    ->addLink('tel:+15551234567')
    ->addTextModule('Doors', 'Doors open at 18:30')
    ->addImageModule('https://example.com/seating-chart.png', 'seating')
    ->save();
```

Each method can be called multiple times. Values hydrate back when fetching a class through `find()` or `all()`, readable via `getLocations()`, `getLinks()`, `getTextModules()`, and `getImageModules()`.

## How

- Four small `Arrayable` value objects under `Builders/Google/Entities`: `Location`, `Link`, `TextModule`, `ImageModule`.
- Compilation and hydration are centralized on the base class (`compileModules()` merged in `save()`, hydration hooked into `hydrateCommonFields()`), so no per-class-type code is duplicated.
- The shared validation rules live in `GooglePassClassValidator::moduleRules()`, merged into `validate()`, so individual class validators stay untouched.

## Backwards compatibility

Fully additive. When none of the new methods are called, the compiled payload is byte-for-byte identical to before (the module keys are omitted entirely). No public signatures changed. No new major version required.

Docs and tests included.