### PR TITLE
Add setBackgroundImage to Apple pass builders

### DIFF
--- a/docs/basic-usage/adding-images.md
+++ b/docs/basic-usage/adding-images.md
@@ -17,6 +17,12 @@ $builder
     ->setIconImage(public_path('images/icon.png'));
 ```
 
+Alongside the logo and icon, you can set a strip, thumbnail, or background image with `setStripImage()`, `setThumbnailImage()`, and `setBackgroundImage()`. The background image is rendered behind event tickets:
+
+```php
+$builder->setBackgroundImage(public_path('images/background.png'));
+```
+
 Apple renders passes at 1x, 2x, and 3x pixel densities. Providing higher-density versions gives you crisper results; pass them as extra arguments:
 
 ```php

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -155,6 +155,13 @@ abstract class ApplePassBuilder
         return $this;
     }
 
+    public function setBackgroundImage(string $x1Path, ?string $x2Path = null, ?string $x3Path = null): self
+    {
+        $this->images['background'] = new Image($x1Path, $x2Path, $x3Path);
+
+        return $this;
+    }
+
     public function setRemoteLogoImage(string $x1Url, ?string $x2Url = null, ?string $x3Url = null): self
     {
         $this->images['logo'] = Image::makeRemote($x1Url, $x2Url, $x3Url);
@@ -179,6 +186,13 @@ abstract class ApplePassBuilder
     public function setRemoteThumbnailImage(string $x1Url, ?string $x2Url = null, ?string $x3Url = null): self
     {
         $this->images['thumbnail'] = Image::makeRemote($x1Url, $x2Url, $x3Url);
+
+        return $this;
+    }
+
+    public function setRemoteBackgroundImage(string $x1Url, ?string $x2Url = null, ?string $x3Url = null): self
+    {
+        $this->images['background'] = Image::makeRemote($x1Url, $x2Url, $x3Url);
 
         return $this;
     }

--- a/tests/Builders/Apple/EventTicketPassBuilderTest.php
+++ b/tests/Builders/Apple/EventTicketPassBuilderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\LaravelMobilePass\Builders\Apple\EventTicketPassBuilder;
+use Spatie\LaravelMobilePass\Support\Apple\PkPassReader;
 
 it('builds a basic event ticket', function () {
     $eventTicketPassBuilder = EventTicketPassBuilder::make()
@@ -26,6 +27,42 @@ it('builds a basic event ticket', function () {
     $generatedPass = $eventTicketPassBuilder->generate();
 
     expect($generatedPass)->toMatchMobilePassSnapshot();
+});
+
+it('bundles a background image into the generated pass', function () {
+    $generatedPass = EventTicketPassBuilder::make()
+        ->setOrganizationName('My organization')
+        ->setSerialNumber(123456)
+        ->setDescription('Hello!')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->setBackgroundImage(
+            getTestSupportPath('images/spatie-thumbnail.png'),
+            getTestSupportPath('images/spatie-thumbnail.png'),
+            getTestSupportPath('images/spatie-thumbnail.png'),
+        )
+        ->generate();
+
+    $reader = PkPassReader::fromString($generatedPass);
+
+    expect($reader->containsFile('background.png'))->toBeTrue()
+        ->and($reader->containsFile('background@2x.png'))->toBeTrue()
+        ->and($reader->containsFile('background@3x.png'))->toBeTrue();
+});
+
+it('registers a remote background image', function () {
+    $pass = EventTicketPassBuilder::make()
+        ->setOrganizationName('My organization')
+        ->setSerialNumber(123456)
+        ->setDescription('Hello!')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->setRemoteBackgroundImage('https://example.com/pass/background.png')
+        ->save();
+
+    expect($pass->images['background'])
+        ->toMatchArray([
+            'x1Path' => 'https://example.com/pass/background.png',
+            'isRemote' => true,
+        ]);
 });
 
 it('has a name', function () {


### PR DESCRIPTION
Closes #49

The docs and Apple's pass spec list a background image for event tickets, but the builders only exposed `setStripImage`/`setThumbnailImage`. This adds `setBackgroundImage()` and `setRemoteBackgroundImage()` to `ApplePassBuilder`, bundling `background.png` (and the @2x/@3x densities) into the generated pass.

```php
$builder->setBackgroundImage(public_path('images/background.png'));
```