### PR TITLE
Add iBeacon relevance support for Apple Wallet passes

### DIFF
--- a/docs/apple-wallet/pass-relevance.md
+++ b/docs/apple-wallet/pass-relevance.md
@@ -53,6 +53,30 @@ $builder->setMaxDistance(500);
 
 Pick a radius that matches the venue: larger for an airport, tighter for a coffee shop.
 
+## Beacons
+
+Locations use GPS. For indoor precision — a specific department in a store, a stand inside a stadium — attach one or more iBeacons instead. The pass surfaces when the device comes within Bluetooth range of a beacon broadcasting a matching identifier:
+
+```php
+$builder->addBeacon(
+    proximityUUID: 'f7826da6-4fa2-4e98-8024-bc5b71e0893e',
+    relevantText: 'Show this pass at the counter',
+);
+```
+
+The optional `major` and `minor` arguments narrow the match to a specific beacon or group of beacons sharing a UUID:
+
+```php
+$builder->addBeacon(
+    proximityUUID: 'f7826da6-4fa2-4e98-8024-bc5b71e0893e',
+    major: 12, // e.g. a store
+    minor: 3,  // e.g. a department
+    relevantText: 'Welcome to the flagship store',
+);
+```
+
+Apple allows up to ten beacons per pass. Omitting `major` and `minor` makes the entry match every beacon broadcasting that UUID, so a single entry can cover an entire fleet of beacons — one per store of a retail chain, for example — sidestepping the ten-location limit. When several entries match, the system shows the `relevantText` of the most specific one.
+
 ## Combining them
 
 Relevance is strongest when a date and a location agree. A concert ticket with both the showtime and the stadium coordinates will surface before the show on the way to the venue, and drop out again once the event is over.

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use PKPass\PKPass;
 use PKPass\PKPassException;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Barcode;
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Beacon;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Color;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\FieldContent;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Image;
@@ -77,6 +78,9 @@ abstract class ApplePassBuilder
 
     /** @var array<int, Location> */
     protected array $locations = [];
+
+    /** @var array<int, Beacon> */
+    protected array $beacons = [];
 
     protected ?NfcPayload $nfc = null;
 
@@ -429,6 +433,17 @@ abstract class ApplePassBuilder
         return $this;
     }
 
+    public function addBeacon(
+        string $proximityUUID,
+        ?int $major = null,
+        ?int $minor = null,
+        ?string $relevantText = null,
+    ): self {
+        $this->beacons[] = new Beacon($proximityUUID, $major, $minor, $relevantText);
+
+        return $this;
+    }
+
     public function setMaxDistance(int $meters): self
     {
         $this->maxDistance = $meters;
@@ -599,6 +614,10 @@ abstract class ApplePassBuilder
                 $this->locations,
             ),
             'maxDistance' => $this->maxDistance,
+            'beacons' => empty($this->beacons) ? null : array_map(
+                fn (Beacon $beacon) => $beacon->toArray(),
+                $this->beacons,
+            ),
             'nfc' => $this->nfc?->toArray(),
             'userInfo' => [
                 'passType' => $this->type->value,
@@ -679,6 +698,11 @@ abstract class ApplePassBuilder
         );
 
         $this->maxDistance = $this->data['maxDistance'] ?? null;
+
+        $this->beacons = array_map(
+            fn (array $beacon) => Beacon::fromArray($beacon),
+            $this->data['beacons'] ?? [],
+        );
 
         $this->nfc = empty($this->data['nfc'])
             ? null

--- a/src/Builders/Apple/Entities/Beacon.php
+++ b/src/Builders/Apple/Entities/Beacon.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Builders\Apple\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Beacon implements Arrayable
+{
+    public function __construct(
+        public string $proximityUUID,
+        public ?int $major = null,
+        public ?int $minor = null,
+        public ?string $relevantText = null,
+    ) {}
+
+    public static function make(
+        string $proximityUUID,
+        ?int $major = null,
+        ?int $minor = null,
+        ?string $relevantText = null,
+    ): self {
+        return new self($proximityUUID, $major, $minor, $relevantText);
+    }
+
+    /** @param  array<string, mixed>  $values */
+    public static function fromArray(array $values): self
+    {
+        return new self(
+            $values['proximityUUID'],
+            isset($values['major']) ? (int) $values['major'] : null,
+            isset($values['minor']) ? (int) $values['minor'] : null,
+            $values['relevantText'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'proximityUUID' => $this->proximityUUID,
+            'major' => $this->major,
+            'minor' => $this->minor,
+            'relevantText' => $this->relevantText,
+        ], fn ($value) => $value !== null);
+    }
+}

--- a/src/Builders/Apple/Validators/ApplePassValidator.php
+++ b/src/Builders/Apple/Validators/ApplePassValidator.php
@@ -23,6 +23,7 @@ abstract class ApplePassValidator
             'relevantDate' => [],
             'locations' => [],
             'maxDistance' => [],
+            'beacons' => [],
             'nfc' => [],
             'semantics' => [],
             'primaryFields' => [],

--- a/tests/Builders/Apple/RelevanceTest.php
+++ b/tests/Builders/Apple/RelevanceTest.php
@@ -64,3 +64,49 @@ it('round-trips relevance data through the uncompile path', function () {
     expect($data['locations'][0]['relevantText'])->toBe('Shea Stadium');
     expect($data['maxDistance'])->toBe(750);
 });
+
+it('serialises beacons onto the pass', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addBeacon(proximityUUID: 'f7826da6-4fa2-4e98-8024-bc5b71e0893e', major: 1, minor: 42, relevantText: 'Welcome to the merch stand')
+        ->addBeacon(proximityUUID: 'e2c56db5-dffb-48d2-b060-d0f5a71096e0')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data)->toHaveKey('beacons');
+    expect($data['beacons'])->toHaveCount(2);
+    expect($data['beacons'][0])->toMatchArray([
+        'proximityUUID' => 'f7826da6-4fa2-4e98-8024-bc5b71e0893e',
+        'major' => 1,
+        'minor' => 42,
+        'relevantText' => 'Welcome to the merch stand',
+    ]);
+    expect($data['beacons'][1])->toMatchArray([
+        'proximityUUID' => 'e2c56db5-dffb-48d2-b060-d0f5a71096e0',
+    ]);
+    expect($data['beacons'][1])->not->toHaveKeys(['major', 'minor', 'relevantText']);
+});
+
+it('round-trips beacons through the uncompile path', function () {
+    $model = MobilePass::factory()->make([
+        'builder_name' => EventTicketPassBuilder::name(),
+        'content' => [
+            'organizationName' => 'Fab Four Promotions',
+            'serialNumber' => 'BTL-SHEA-0042',
+            'description' => 'The Beatles at Shea Stadium',
+            'beacons' => [
+                ['proximityUUID' => 'f7826da6-4fa2-4e98-8024-bc5b71e0893e', 'major' => 0, 'minor' => 7, 'relevantText' => 'Merch stand'],
+            ],
+        ],
+    ]);
+
+    $data = EventTicketPassBuilder::hydrate($model)->data();
+
+    expect($data['beacons'])->toHaveCount(1);
+    expect($data['beacons'][0]['proximityUUID'])->toBe('f7826da6-4fa2-4e98-8024-bc5b71e0893e');
+    expect($data['beacons'][0]['major'])->toBe(0);
+    expect($data['beacons'][0]['minor'])->toBe(7);
+    expect($data['beacons'][0]['relevantText'])->toBe('Merch stand');
+});


### PR DESCRIPTION
## What this PR does

This PR adds support for iBeacon relevance on Apple Wallet passes, completing the pass relevance surface alongside the existing `setRelevantDate()` and `addLocation()` support.

Apple Wallet can surface a pass on the lock screen when the device comes within Bluetooth range of an iBeacon — useful for indoor precision where GPS locations fall short (a department inside a store, a stand inside a stadium). See [Pass.Beacons](https://developer.apple.com/documentation/walletpasses/pass/beacons) in Apple's reference.

## Usage

```php
$builder->addBeacon(
    proximityUUID: 'f7826da6-4fa2-4e98-8024-bc5b71e0893e',
    relevantText: 'Show this pass at the counter',
);
```

The optional `major` and `minor` arguments narrow the match to a specific beacon or group of beacons sharing a UUID:

```php
$builder->addBeacon(
    proximityUUID: 'f7826da6-4fa2-4e98-8024-bc5b71e0893e',
    major: 12, // e.g. a store
    minor: 3,  // e.g. a department
    relevantText: 'Welcome to the flagship store',
);
```

Apple allows up to ten beacons per pass. Omitting `major` and `minor` matches every beacon broadcasting that UUID, so a single entry can cover an entire beacon fleet (e.g. one beacon per store of a retail chain) — a practical way around the ten-location limit of `locations`.

## Changes

- New `Beacon` entity, mirroring the `Location` entity (constructor promotion, `make()`, `fromArray()`, `toArray()` with null filtering — `major: 0` is preserved, as `0` is a valid identifier)
- `addBeacon()` on `ApplePassBuilder`, plus serialization in `data()` and hydration in the uncompile path, following the existing `locations` code paths
- `beacons` key registered in `ApplePassValidator`
- Two Pest tests in `RelevanceTest`: serialization (including asserting omitted optional keys don't leak into the JSON) and a round-trip through the hydrate path
- New "Beacons" section in `docs/apple-wallet/pass-relevance.md`

Beacon relevance is Apple-only; Google Wallet has no beacon equivalent, consistent with the note already in the relevance docs.

No breaking changes — passes without beacons serialize exactly as before (`beacons` is omitted when empty, matching the `locations` behavior).