### PR TITLE
Add link, text and image modules to Google objects

### DIFF
--- a/src/Builders/Google/GooglePassBuilder.php
+++ b/src/Builders/Google/GooglePassBuilder.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Str;
 use RuntimeException;
 use Spatie\LaravelMobilePass\Actions\Google\CreateGoogleObjectAction;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Barcode;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\Image;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\ImageModule;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\Link;
+use Spatie\LaravelMobilePass\Builders\Google\Entities\TextModule;
 use Spatie\LaravelMobilePass\Builders\Google\Validators\GooglePassObjectValidator;
 use Spatie\LaravelMobilePass\Enums\BarcodeType;
 use Spatie\LaravelMobilePass\Enums\PassType;
@@ -29,6 +33,15 @@ abstract class GooglePassBuilder
     protected string $state = 'ACTIVE';
 
     protected PassType $type;
+
+    /** @var array<int, Link> */
+    protected array $links = [];
+
+    /** @var array<int, TextModule> */
+    protected array $textModules = [];
+
+    /** @var array<int, ImageModule> */
+    protected array $imageModules = [];
 
     abstract protected static function validator(): GooglePassObjectValidator;
 
@@ -94,6 +107,45 @@ abstract class GooglePassBuilder
         );
     }
 
+    public function addLink(string $uri, ?string $description = null): static
+    {
+        $this->links[] = new Link($uri, $description);
+
+        return $this;
+    }
+
+    public function addTextModule(string $header, string $body, ?string $id = null): static
+    {
+        $this->textModules[] = new TextModule($header, $body, $id);
+
+        return $this;
+    }
+
+    public function addImageModule(string $imageUrl, ?string $id = null): static
+    {
+        $this->imageModules[] = new ImageModule(Image::fromUrl($imageUrl), $id);
+
+        return $this;
+    }
+
+    /** @return array<int, Link> */
+    public function getLinks(): array
+    {
+        return $this->links;
+    }
+
+    /** @return array<int, TextModule> */
+    public function getTextModules(): array
+    {
+        return $this->textModules;
+    }
+
+    /** @return array<int, ImageModule> */
+    public function getImageModules(): array
+    {
+        return $this->imageModules;
+    }
+
     public function objectId(): string
     {
         $this->objectSuffix ??= (string) Str::uuid();
@@ -147,7 +199,27 @@ abstract class GooglePassBuilder
             'classId' => $this->classId(),
             'state' => $this->state,
             'barcode' => $this->compileBarcode(),
-        ], $this->compileData()));
+        ], $this->compileData(), $this->compileModules()));
+    }
+
+    /** @return array<string, mixed> */
+    protected function compileModules(): array
+    {
+        return $this->filterEmpty([
+            'linksModuleData' => $this->compileLinks(),
+            'textModulesData' => array_map(fn (TextModule $module) => $module->toArray(), $this->textModules),
+            'imageModulesData' => array_map(fn (ImageModule $module) => $module->toArray(), $this->imageModules),
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    protected function compileLinks(): array
+    {
+        if ($this->links === []) {
+            return [];
+        }
+
+        return ['uris' => array_map(fn (Link $link) => $link->toArray(), $this->links)];
     }
 
     /** @return array<string, mixed>|null */

--- a/src/Builders/Google/Validators/GooglePassObjectValidator.php
+++ b/src/Builders/Google/Validators/GooglePassObjectValidator.php
@@ -15,12 +15,35 @@ abstract class GooglePassObjectValidator
      */
     public function validate(array $payload): array
     {
-        $validator = validator($payload, $this->rules());
+        $validator = validator($payload, $this->rules() + $this->moduleRules());
 
         if ($validator->fails()) {
             throw new InvalidPass($validator);
         }
 
         return $validator->validated();
+    }
+
+    /**
+     * Module fields are shared by every Google object type, so they live here
+     * instead of being repeated in each object validator.
+     *
+     * @return array<string, array<int, string>>
+     */
+    protected function moduleRules(): array
+    {
+        return [
+            'linksModuleData' => ['nullable', 'array'],
+            'linksModuleData.uris' => ['nullable', 'array'],
+            'linksModuleData.uris.*.uri' => ['nullable', 'string'],
+            'linksModuleData.uris.*.description' => ['nullable', 'string'],
+            'textModulesData' => ['nullable', 'array'],
+            'textModulesData.*.header' => ['nullable', 'string'],
+            'textModulesData.*.body' => ['nullable', 'string'],
+            'textModulesData.*.id' => ['nullable', 'string'],
+            'imageModulesData' => ['nullable', 'array'],
+            'imageModulesData.*.mainImage' => ['nullable', 'array'],
+            'imageModulesData.*.id' => ['nullable', 'string'],
+        ];
     }
 }

--- a/tests/Builders/Google/GoogleObjectModulesTest.php
+++ b/tests/Builders/Google/GoogleObjectModulesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Spatie\LaravelMobilePass\Builders\Google\GenericPassBuilder;
+use Spatie\LaravelMobilePass\Builders\Google\LoyaltyPassBuilder;
+use Spatie\LaravelMobilePass\Tests\TestSupport\Google\GoogleFixtures;
+
+beforeEach(function () {
+    config()->set('mobile-pass.google.service_account_key_path', GoogleFixtures::serviceAccountPath());
+    config()->set('mobile-pass.google.issuer_id', '3388');
+    config()->set('mobile-pass.google.api_base_url', 'https://example.com/walletobjects/v1');
+    cache()->put('mobile-pass.google.access-token', 'test-token', 3600);
+});
+
+it('sends link, text and image modules on the object to Google', function () {
+    Http::fake(['*/genericObject' => Http::response([], 200)]);
+
+    $pass = GenericPassBuilder::make()
+        ->setClass('membership')
+        ->setObjectSuffix('alpha')
+        ->setCardTitle('Acme Inc')
+        ->addLink('https://example.com/my-card/alpha', 'My card')
+        ->addLink('tel:+3232001212')
+        ->addTextModule('Notes', 'Show this pass at the entrance', 'notes')
+        ->addImageModule('https://cdn.example.com/member.png', 'photo')
+        ->save();
+
+    expect($pass->content['googleObjectPayload']['linksModuleData']['uris'][0]['uri'])
+        ->toBe('https://example.com/my-card/alpha');
+
+    Http::assertSent(function ($request) {
+        expect($request['linksModuleData']['uris'][0]['uri'])->toBe('https://example.com/my-card/alpha');
+        expect($request['linksModuleData']['uris'][0]['description'])->toBe('My card');
+        expect($request['linksModuleData']['uris'][1]['uri'])->toBe('tel:+3232001212');
+        expect($request['linksModuleData']['uris'][1])->not->toHaveKey('description');
+
+        expect($request['textModulesData'][0]['header'])->toBe('Notes');
+        expect($request['textModulesData'][0]['body'])->toBe('Show this pass at the entrance');
+        expect($request['textModulesData'][0]['id'])->toBe('notes');
+
+        expect($request['imageModulesData'][0]['mainImage']['sourceUri']['uri'])->toBe('https://cdn.example.com/member.png');
+        expect($request['imageModulesData'][0]['id'])->toBe('photo');
+
+        return true;
+    });
+});
+
+it('makes the module methods available on every object builder type', function () {
+    Http::fake(['*/loyaltyObject' => Http::response([], 200)]);
+
+    LoyaltyPassBuilder::make()
+        ->setClass('lp-2026')
+        ->setObjectSuffix('jane')
+        ->setAccountId('AC-42')
+        ->setAccountName('Jane Doe')
+        ->addLink('https://example.com/points/jane', 'My points')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request['linksModuleData']['uris'][0]['uri'])->toBe('https://example.com/points/jane');
+        expect($request['linksModuleData']['uris'][0]['description'])->toBe('My points');
+
+        return true;
+    });
+});
+
+it('omits the module keys entirely when none are set', function () {
+    Http::fake(['*/genericObject' => Http::response([], 200)]);
+
+    GenericPassBuilder::make()
+        ->setClass('membership')
+        ->setObjectSuffix('beta')
+        ->setCardTitle('Acme Inc')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request->data())->not->toHaveKey('linksModuleData');
+        expect($request->data())->not->toHaveKey('textModulesData');
+        expect($request->data())->not->toHaveKey('imageModulesData');
+
+        return true;
+    });
+});


### PR DESCRIPTION
## What

#48 exposed Google Wallet's shared building blocks (links, text modules, image modules) on **classes**. This PR completes the symmetry by exposing the same modules on **objects**, where Google's API equally supports them ([genericObject.linksModuleData](https://developers.google.com/wallet/generic/rest/v1/genericobject) etc.).

The new `addLink()`, `addTextModule()` and `addImageModule()` methods live on the `GooglePassBuilder` base, so they are available on every object type (generic, loyalty, offer, event ticket, boarding), reusing the `Link`/`TextModule`/`ImageModule` entities from #48. Validation follows the same pattern: shared `moduleRules()` on the abstract object validator.

## Why

Class-level links are shared by every pass of the class, so they can't express per-pass content. Object-level links can — the motivating use case is a personal account/membership URL on each issued pass (e.g. a tokenized "my pass" page), which Apple passes already support via back fields.

## Notes

- `locations` is intentionally **not** added on objects: Google has deprecated location-based relevance on Wallet objects.
- Purely additive: when no modules are set, `filterEmpty()` drops the keys and compiled payloads are byte-for-byte identical to before (covered by a regression test).
- Tests mirror `GoogleClassModulesTest`. Full suite, Pint and PHPStan pass.

Refs #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)