### PR TITLE
Keep falsy scalar values like "0" in Apple entity serialization

### DIFF
--- a/src/Builders/Apple/Entities/Barcode.php
+++ b/src/Builders/Apple/Entities/Barcode.php
@@ -48,6 +48,6 @@ class Barcode implements Arrayable
             'message' => $this->message,
             'messageEncoding' => $this->messageEncoding,
             'altText' => $this->altText,
-        ]);
+        ], fn ($value) => $value !== null);
     }
 }

--- a/src/Builders/Apple/Entities/FieldContent.php
+++ b/src/Builders/Apple/Entities/FieldContent.php
@@ -166,6 +166,6 @@ class FieldContent implements Arrayable
             'numberStyle' => $this->numberStyle?->value,
             'textAlignment' => $this->textAlignment?->value,
             'timeStyle' => $this->timeStyle?->value,
-        ]);
+        ], fn ($value) => $value !== null);
     }
 }

--- a/src/Builders/Apple/Entities/PersonName.php
+++ b/src/Builders/Apple/Entities/PersonName.php
@@ -59,6 +59,6 @@ class PersonName implements Arrayable
             'namePrefix' => $this->namePrefix,
             'nickname' => $this->nickname,
             'phoneticRepresentation' => $this->phoneticRepresentation,
-        ]);
+        ], fn ($value) => $value !== null);
     }
 }

--- a/src/Builders/Apple/Entities/Seat.php
+++ b/src/Builders/Apple/Entities/Seat.php
@@ -55,6 +55,6 @@ class Seat implements Arrayable
             'row' => $this->row,
             'section' => $this->section,
             'type' => $this->type,
-        ]);
+        ], fn ($value) => $value !== null);
     }
 }

--- a/tests/Builders/Apple/StoreCardPassBuilderTest.php
+++ b/tests/Builders/Apple/StoreCardPassBuilderTest.php
@@ -20,6 +20,22 @@ it('compiles back fields into the store card payload', function () {
     ]);
 });
 
+it('keeps a zero-valued primary field in the compiled payload', function () {
+    $compiledData = StoreCardPassBuilder::make()
+        ->setOrganizationName('My organization')
+        ->setSerialNumber(123456)
+        ->setDescription('Hello!')
+        ->addField('balance', '0', label: 'Points')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($compiledData['storeCard']['primaryFields'][0])->toMatchArray([
+        'key' => 'balance',
+        'label' => 'Points',
+        'value' => '0',
+    ]);
+});
+
 it('has a name', function () {
     expect(StoreCardPassBuilder::name())->toBe('store_card');
 });

--- a/tests/Entities/FieldContentTest.php
+++ b/tests/Entities/FieldContentTest.php
@@ -20,6 +20,18 @@ it('builds a field content with a label and value', function () {
     ]);
 });
 
+it('keeps falsy values like "0"', function () {
+    $pass = FieldContent::make(key: 'balance')
+        ->withLabel('Points')
+        ->withValue('0');
+
+    expect($pass->toArray())->toBe([
+        'key' => 'balance',
+        'label' => 'Points',
+        'value' => '0',
+    ]);
+});
+
 it('translates the :value placeholder to Apple\'s %@ format in change messages', function () {
     $pass = FieldContent::make(key: 'seat')
         ->showMessageWhenChanged('Your seat has changed to :value');


### PR DESCRIPTION
## What's wrong

`FieldContent::toArray()` runs its output through `array_filter()` without a callback, so every falsy value is dropped — most notably a field value of `"0"`:

```php
StoreCardPassBuilder::make()
    ->addField('balance', '0', label: 'Points')
    // compiles to {"key": "balance", "label": "Points"} — no value at all
```

For a loyalty/store card, zero is the default balance of every new customer, so every freshly issued pass ships a primary field with no value. The same idiom sits in `Barcode` (a numeric message of `"0"`), `Seat` (row/number `"0"`), and `PersonName`.

## The fix

`Location`, `NfcPayload`, and `Beacon` already filter with `fn ($value) => $value !== null` — this PR aligns the four remaining entities with that existing pattern.

One behavior note: an explicitly set `false` (e.g. `ignoresTimezone`) is now emitted instead of silently dropped. That's spec-equivalent for Apple Wallet, which treats an absent boolean as false.

## Tests

Added a `FieldContent` unit test and a `StoreCardPassBuilder` end-to-end test pinning the `"0"` value. 