### PR TITLE
Add points labels and secondaryLoyaltyPoints to the loyalty builder

### DIFF
--- a/src/Builders/Google/LoyaltyPassBuilder.php
+++ b/src/Builders/Google/LoyaltyPassBuilder.php
@@ -18,6 +18,14 @@ class LoyaltyPassBuilder extends GooglePassBuilder
 
     protected ?string $balanceString = null;
 
+    protected ?string $balanceLabel = null;
+
+    protected ?int $secondaryBalanceMicros = null;
+
+    protected ?string $secondaryBalanceString = null;
+
+    protected ?string $secondaryBalanceLabel = null;
+
     protected static function validator(): GooglePassObjectValidator
     {
         return new LoyaltyObjectValidator;
@@ -61,22 +69,62 @@ class LoyaltyPassBuilder extends GooglePassBuilder
         return $this;
     }
 
+    public function setBalanceLabel(string $label): self
+    {
+        $this->balanceLabel = $label;
+
+        return $this;
+    }
+
+    public function setSecondaryBalanceMicros(int $micros): self
+    {
+        $this->secondaryBalanceMicros = $micros;
+
+        return $this;
+    }
+
+    public function setSecondaryBalanceString(string $value): self
+    {
+        $this->secondaryBalanceString = $value;
+
+        return $this;
+    }
+
+    public function setSecondaryBalanceLabel(string $label): self
+    {
+        $this->secondaryBalanceLabel = $label;
+
+        return $this;
+    }
+
     /** @return array<string, mixed> */
     protected function compileData(): array
     {
-        $balance = $this->filterEmpty([
-            'micros' => $this->balanceMicros,
-            'string' => $this->balanceString,
-        ]);
-
-        $loyaltyPoints = $this->filterEmpty([
-            'balance' => $balance,
-        ]);
-
         return $this->filterEmpty([
             'accountId' => $this->accountId,
             'accountName' => $this->accountName,
-            'loyaltyPoints' => $loyaltyPoints,
+            'loyaltyPoints' => $this->compilePoints(
+                $this->balanceLabel,
+                $this->balanceMicros,
+                $this->balanceString,
+            ),
+            'secondaryLoyaltyPoints' => $this->compilePoints(
+                $this->secondaryBalanceLabel,
+                $this->secondaryBalanceMicros,
+                $this->secondaryBalanceString,
+            ),
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    protected function compilePoints(?string $label, ?int $micros, ?string $string): array
+    {
+        return $this->filterEmpty([
+            'label' => $label,
+            'balance' => $this->filterEmpty([
+                'micros' => $micros,
+                'string' => $string,
+            ]),
         ]);
     }
 }

--- a/src/Builders/Google/Validators/LoyaltyObjectValidator.php
+++ b/src/Builders/Google/Validators/LoyaltyObjectValidator.php
@@ -13,6 +13,7 @@ class LoyaltyObjectValidator extends GooglePassObjectValidator
             'accountId' => ['nullable', 'string'],
             'accountName' => ['nullable', 'string'],
             'loyaltyPoints' => ['nullable', 'array'],
+            'secondaryLoyaltyPoints' => ['nullable', 'array'],
             'barcode' => ['nullable', 'array'],
         ];
     }

--- a/tests/Builders/Google/LoyaltyPassBuilderTest.php
+++ b/tests/Builders/Google/LoyaltyPassBuilderTest.php
@@ -42,6 +42,44 @@ it('creates a MobilePass row and POSTs the loyalty object to Google', function (
     });
 });
 
+it('compiles points labels and secondary loyalty points', function () {
+    Http::fake(['*/loyaltyObject' => Http::response([], 200)]);
+
+    LoyaltyPassBuilder::make()
+        ->setClass('lp-2026')
+        ->setObjectSuffix('jane')
+        ->setBalanceString('125')
+        ->setBalanceLabel('Points')
+        ->setSecondaryBalanceString('Gold')
+        ->setSecondaryBalanceLabel('Tier')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request['loyaltyPoints']['label'])->toBe('Points');
+        expect($request['loyaltyPoints']['balance']['string'])->toBe('125');
+        expect($request['secondaryLoyaltyPoints']['label'])->toBe('Tier');
+        expect($request['secondaryLoyaltyPoints']['balance']['string'])->toBe('Gold');
+
+        return true;
+    });
+});
+
+it('omits secondaryLoyaltyPoints when no secondary balance is set', function () {
+    Http::fake(['*/loyaltyObject' => Http::response([], 200)]);
+
+    LoyaltyPassBuilder::make()
+        ->setClass('lp-2026')
+        ->setObjectSuffix('jane')
+        ->setBalanceString('125')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request->data())->not->toHaveKey('secondaryLoyaltyPoints');
+
+        return true;
+    });
+});
+
 it('throws when setClass() is not called', function () {
     LoyaltyPassBuilder::make()->setAccountId('AC-42')->save();
 })->throws(RuntimeException::class);


### PR DESCRIPTION
## What this adds

The Google Wallet `LoyaltyObject` supports two things the loyalty builder can't currently express:

- a **`label`** on `loyaltyPoints` — without it, issuers can't control the caption above the balance (Google falls back to a locale default), and
- the **`secondaryLoyaltyPoints`** slot — the only way to render a second value on the **card face** (a member name, rewards tier, stamp count…). `accountName` doesn't help here: Google renders it exclusively in the details section below the card.

```php
LoyaltyPassBuilder::make()
    ->setClass('coffee-club')
    ->setObjectSuffix('jane')
    ->setBalanceString('338')
    ->setBalanceLabel('Points')
    ->setSecondaryBalanceString('Jane')
    ->setSecondaryBalanceLabel('Member')
    ->save();
```

The four new setters (`setBalanceLabel`, `setSecondaryBalanceMicros`, `setSecondaryBalanceString`, `setSecondaryBalanceLabel`) mirror the existing balance setters, `compileData()` assembles both points objects through a shared helper, and `LoyaltyObjectValidator` gains the `secondaryLoyaltyPoints` rule.

## Tests

Two new tests: labels + secondary compile into the POSTed payload, and `secondaryLoyaltyPoints` is omitted entirely when unset. Full suite passes (260 passed, 661 assertions).

Verified against the live Wallet API: an object with `secondaryLoyaltyPoints` renders the second label/value pair on the card face next to the points.