### PR TITLE
feat: add sharingProhibited support to Apple passes

### DIFF
--- a/docs/apple-wallet/apple-specific-methods.md
+++ b/docs/apple-wallet/apple-specific-methods.md
@@ -32,3 +32,11 @@ $builder->setTotalPrice(Price::make(amount: '49.50', currencyCode: 'USD'));
 ```
 
 The price lands on the pass's `semantics.totalPrice`, so Apple can surface it consistently in Wallet and Mail previews.
+
+## Sharing
+
+Wallet shows a Share button on the back of every pass by default. Hide it with `setSharingProhibited(true)`:
+
+```php
+$builder->setSharingProhibited(true);
+```

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -54,6 +54,8 @@ abstract class ApplePassBuilder
 
     protected ?string $description = null;
 
+    protected ?bool $sharingProhibited = null;
+
     protected ?Price $totalPrice = null;
 
     protected ?Collection $wifiDetails = null;
@@ -372,6 +374,14 @@ abstract class ApplePassBuilder
     public function setDescription(string $description): static
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+    /** A Boolean value that determines whether to show the Share button on the back of a pass. Set to true to hide the Share button. */
+    public function setSharingProhibited(bool $sharingProhibited): static
+    {
+        $this->sharingProhibited = $sharingProhibited;
 
         return $this;
     }
@@ -734,6 +744,7 @@ abstract class ApplePassBuilder
             'webServiceURL' => $this->webServiceURL(),
             'teamIdentifier' => self::appleConfig('team_identifier'),
             'description' => $this->description,
+            'sharingProhibited' => $this->sharingProhibited,
             'semantics' => $this->compileSemantics(),
             'backgroundColor' => (string) $this->backgroundColor,
             'foregroundColor' => (string) $this->foregroundColor,
@@ -822,6 +833,7 @@ abstract class ApplePassBuilder
         $this->authenticationToken = $this->data['authenticationToken'] ?? null;
         $this->teamIdentifier = $this->data['teamIdentifier'] ?? null;
         $this->description = $this->data['description'] ?? null;
+        $this->sharingProhibited = $this->data['sharingProhibited'] ?? null;
         $this->backgroundColor = Color::makeFromRgbString($this->data['backgroundColor'] ?? null);
         $this->foregroundColor = Color::makeFromRgbString($this->data['foregroundColor'] ?? null);
         $this->labelColor = Color::makeFromRgbString($this->data['labelColor'] ?? null);

--- a/src/Builders/Apple/Validators/ApplePassValidator.php
+++ b/src/Builders/Apple/Validators/ApplePassValidator.php
@@ -10,6 +10,7 @@ abstract class ApplePassValidator
     {
         return [
             'description' => ['required', 'string'],
+            'sharingProhibited' => ['nullable', 'boolean'],
             'formatVersion' => ['required', 'integer', 'in:1'],
             'organizationName' => ['required', 'string'],
             'passTypeIdentifier' => ['required', 'string'],

--- a/tests/Builders/Apple/SharingTest.php
+++ b/tests/Builders/Apple/SharingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\EventTicketPassBuilder;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+it('serialises sharing prohibited onto the pass', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->setSharingProhibited(true)
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data)->toHaveKey('sharingProhibited');
+    expect($data['sharingProhibited'])->toBeTrue();
+});
+
+it('round-trips sharing prohibited through the uncompile path', function () {
+    $model = MobilePass::factory()->make([
+        'builder_name' => EventTicketPassBuilder::name(),
+        'content' => [
+            'organizationName' => 'Fab Four Promotions',
+            'serialNumber' => 'BTL-SHEA-0042',
+            'description' => 'The Beatles at Shea Stadium',
+            'sharingProhibited' => true,
+        ],
+    ]);
+
+    $data = EventTicketPassBuilder::hydrate($model)->data();
+
+    expect($data['sharingProhibited'])->toBeTrue();
+});


### PR DESCRIPTION
**sharingProhibited** — Apple's top-level Pass.json boolean for hiding the Share button on the back of a pass — was completely missing from the package. Confirmed via a full-repo search: no reference anywhere in src/, tests/, or docs/.                                                                                                        
                                                                                                                                                                            
This adds it to the shared ApplePassBuilder base class, so it's available uniformly on every Apple pass type (event ticket, boarding pass, coupon, generic, store card)  rather than needing to be added per builder:                                                                                                                              
                                                                                                                                                                            
`$builder->setSharingProhibited(true); `                                                                                                                                    
                                                                                                                                                                                                                                                                                                                             
Adding the property/setter and wiring it into compileData()/uncompileContent() wasn't enough — the field silently disappeared from the compiled output even when set to  true. Root cause: `ApplePassValidator::validate() `calls Laravel's `$validator->validated()`, which only returns keys that have an explicit rule entry in rules().            

sharingProhibited had none, so it was compiled correctly and then silently stripped at the validation gate. Every existing subclass validator  (EventTicketApplePassValidator, BoardingApplePassValidator, etc.) merges with `parent::rules()`, so adding one `'sharingProhibited' => ['nullable', 'boolean']` entry to the  base `ApplePassValidator::rules() `fixes it everywhere at once.                                                                                                             
                                                                                                                                                                            
**What's intentionally not touched**                                                                                                                                          
                                                                                                                                                                            
`compileData()`'s `inner array_filter([...])` and `data()`'s outer `array_filter(..., fn ($value) => ! empty($value))` both predate this change and would strip `sharingProhibited === false` from the compiled output before it even reaches the validator. This is inert for this specific field — Apple's own default is false, so there's no behavioral  difference between "explicitly false" and "not set" — so it's left as-is rather than folded into this PR. Flagging here for visibility since it's the kind of  falsy-stripping gotcha that's bitten other boolean semantic tags in this codebase before.                                                                                 
                                                                                                                                                                            
**Testing**                                                                                                                                                                   
                                                                                                                                                                            
New tests/Builders/Apple/SharingTest.php, matching the existing RelevanceTest.php pattern for base-class cross-cutting properties: one test asserting  `setSharingProhibited(true)` reaches ->data(), one round-trip test via `MobilePass::factory() `+ `hydrate()`. Full suite passes.      