### PR TITLE
feat: add Code39, Codabar, and Ean13 barcode types

### DIFF
--- a/docs/basic-usage/adding-barcodes.md
+++ b/docs/basic-usage/adding-barcodes.md
@@ -3,9 +3,11 @@ title: Adding barcodes
 weight: 4
 ---
 
-Barcodes are the scannable bit of a pass: a QR code at a festival gate, a PDF417 on a boarding pass, an Aztec for a bus ticket. Both Apple and Google Wallet understand the same four formats, and the package exposes them through a shared `BarcodeType` enum.
+Barcodes are the scannable bit of a pass: a QR code at a festival gate, a PDF417 on a boarding pass, an Aztec for a bus ticket. The package exposes barcode formats through a shared `BarcodeType` enum, restricted to the formats both Apple and Google Wallet understand.
 
-The four cases on `BarcodeType` are `Qr`, `Pdf417`, `Aztec`, and `Code128`. Pick the one your scanners expect.
+The seven cases on `BarcodeType` are `Qr`, `Pdf417`, `Aztec`, `Code128`, `Code39`, `Codabar`, and `Ean13`. Pick the one your scanners expect.
+
+Apple's Wallet Passes reference also documents an eighth format, `PKBarcodeFormatI2of5` (generic Interleaved 2 of 5) — it's deliberately left out of `BarcodeType`. Google Wallet's closest equivalent, `ITF_14`, is a narrower 14-digit GTIN variant, not the same symbology, so there's no faithful cross-platform mapping for it. Since `BarcodeType` exists specifically so the same call works on both platforms, and any scanner setup choosing a barcode format should already be picking one both platforms render correctly, this isn't expected to be a real limitation in practice.
 
 ## Apple
 
@@ -49,4 +51,4 @@ EventTicketPassBuilder::make()
     ->save();
 ```
 
-The builder translates the `BarcodeType` case into Google's own format names (`QR_CODE`, `PDF_417`, `AZTEC`, `CODE_128`) when it builds the payload.
+The builder translates the `BarcodeType` case into Google's own format names (`QR_CODE`, `PDF_417`, `AZTEC`, `CODE_128`, `CODE_39`, `CODABAR`, `EAN_13`) when it builds the payload.

--- a/src/Builders/Google/GooglePassBuilder.php
+++ b/src/Builders/Google/GooglePassBuilder.php
@@ -243,6 +243,9 @@ abstract class GooglePassBuilder
             BarcodeType::Pdf417 => 'PDF_417',
             BarcodeType::Aztec => 'AZTEC',
             BarcodeType::Code128 => 'CODE_128',
+            BarcodeType::Code39 => 'CODE_39',
+            BarcodeType::Codabar => 'CODABAR',
+            BarcodeType::Ean13 => 'EAN_13',
         };
     }
 

--- a/src/Enums/BarcodeType.php
+++ b/src/Enums/BarcodeType.php
@@ -8,4 +8,7 @@ enum BarcodeType: string
     case Pdf417 = 'PKBarcodeFormatPDF417';
     case Aztec = 'PKBarcodeFormatAztec';
     case Code128 = 'PKBarcodeFormatCode128';
+    case Code39 = 'PKBarcodeFormatCode39';
+    case Codabar = 'PKBarcodeFormatCodabar';
+    case Ean13 = 'PKBarcodeFormatEAN13';
 }

--- a/tests/Builders/Google/BarcodeTypeTest.php
+++ b/tests/Builders/Google/BarcodeTypeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Spatie\LaravelMobilePass\Builders\Google\GenericPassBuilder;
+use Spatie\LaravelMobilePass\Enums\BarcodeType;
+use Spatie\LaravelMobilePass\Tests\TestSupport\Google\GoogleFixtures;
+
+beforeEach(function () {
+    config()->set('mobile-pass.google.service_account_key_path', GoogleFixtures::serviceAccountPath());
+    config()->set('mobile-pass.google.issuer_id', '3388');
+    config()->set('mobile-pass.google.api_base_url', 'https://example.com/walletobjects/v1');
+    cache()->put('mobile-pass.google.access-token', 'test-token', 3600);
+});
+
+it('translates BarcodeType::Code39 to Google\'s CODE_39', function () {
+    Http::fake(['*/genericObject' => Http::response([], 200)]);
+
+    GenericPassBuilder::make()
+        ->setClass('gen-2026')
+        ->setObjectSuffix('alpha')
+        ->setHeader('Member Card')
+        ->setBarcode(BarcodeType::Code39, 'MEMBER-42')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request['barcode']['type'])->toBe('CODE_39');
+
+        return true;
+    });
+});
+
+it('translates BarcodeType::Codabar to Google\'s CODABAR', function () {
+    Http::fake(['*/genericObject' => Http::response([], 200)]);
+
+    GenericPassBuilder::make()
+        ->setClass('gen-2026')
+        ->setObjectSuffix('alpha')
+        ->setHeader('Member Card')
+        ->setBarcode(BarcodeType::Codabar, 'MEMBER-42')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request['barcode']['type'])->toBe('CODABAR');
+
+        return true;
+    });
+});
+
+it('translates BarcodeType::Ean13 to Google\'s EAN_13', function () {
+    Http::fake(['*/genericObject' => Http::response([], 200)]);
+
+    GenericPassBuilder::make()
+        ->setClass('gen-2026')
+        ->setObjectSuffix('alpha')
+        ->setHeader('Member Card')
+        ->setBarcode(BarcodeType::Ean13, 'MEMBER-42')
+        ->save();
+
+    Http::assertSent(function ($request) {
+        expect($request['barcode']['type'])->toBe('EAN_13');
+
+        return true;
+    });
+});


### PR DESCRIPTION
## What                                                                                                                                                                   
                                                                                                                                                                            
  Apple's Wallet Passes reference documents 8 `PKBarcodeFormat*` values, but `BarcodeType` only exposed the original 4 (`Qr`, `Pdf417`, `Aztec`, `Code128`). Verified  against Apple's and Google's *current* docs (not from memory — confirmed each format is genuinely documented before adding it) and added the 3 new ones that have a clean, faithful equivalent on both platforms:                                                                                                                                    
                                                                                                                                                                            
  | `BarcodeType` case | Apple | Google |                                                                                                                                   
  |---|---|---|                                                                                                                                                             
  | `Code39` | `PKBarcodeFormatCode39` | `CODE_39` |                                                                                                                        
  | `Codabar` | `PKBarcodeFormatCodabar` | `CODABAR` |                                                                                                                      
  | `Ean13` | `PKBarcodeFormatEAN13` | `EAN_13` |                                                                                                                           
                                                                                                                                                                            
  ## Why the 4th documented format isn't here                                                                                                                               
                                                                                                                                                                            
  Apple also documents `PKBarcodeFormatI2of5` (generic Interleaved 2 of 5). It's deliberately excluded: Google Wallet's closest option, `ITF_14`, is a narrower 14-digit  GTIN variant, not the same symbology — there's no faithful cross-platform mapping. `BarcodeType` is a *shared* enum specifically so the same `setBarcode()` call works on both platforms (`GooglePassBuilder::translateBarcodeType()` is a non-exhaustive `match` keyed on it), so adding a case with no honest Google equivalent would either silently mis-encode the barcode or need a special-cased exception — worse than just not having it. Anyone picking a barcode format for a cross-platform pass should already be choosing one both platforms render correctly, so this isn't expected to be a real-world limitation.                                                            
                                                                                                                                                                            
  ## Testing                                                                                                                                                                
                                                                                                                                                                            
  New `tests/Builders/Google/BarcodeTypeTest.php` — one test per new case, asserting the Google API payload's `barcode.type` matches. The Apple side needed no dedicated  test: `Barcode::toArray()` is fully generic (`$this->format->value`), already exercised by every existing Apple barcode test via `BarcodeType::Qr`, so a new case carries zero additional Apple-side risk. Full suite passes.    