### PR TITLE
feat: Apple multiple barcodes

### DIFF
--- a/docs/basic-usage/adding-barcodes.md
+++ b/docs/basic-usage/adding-barcodes.md
@@ -35,7 +35,15 @@ $builder->setBarcode(
 );
 ```
 
-Under the hood the builder writes the barcode into both `barcode` (for older iOS) and `barcodes` (for iOS 9+) so the pass renders everywhere.
+Under the hood the builder writes into both `barcode` (deprecated, for pre-`barcodes` iOS) and `barcodes` (the full list Wallet actually reads). As of iOS 27, `barcodes` supports genuine fallback: pass more than one and Wallet picks the first format it supports, in order — e.g. an EAN13 barcode for iOS 27+ devices with a QR fallback for older ones:
+
+```php
+$builder
+    ->addBarcode(BarcodeType::Ean13, '4006381333931')
+    ->addBarcode(BarcodeType::Qr, 'TICKET-12345');
+```
+
+`addBarcode()` appends to the list; `setBarcode()` still replaces it entirely with a single barcode, exactly as before. The deprecated singular `barcode` key is always populated from the *last* entry in the list — the most broadly-compatible format, for the oldest devices that only read that key.
 
 ## Google
 

--- a/docs/basic-usage/adding-barcodes.md
+++ b/docs/basic-usage/adding-barcodes.md
@@ -35,11 +35,11 @@ $builder->setBarcode(
 );
 ```
 
-Under the hood the builder writes into both `barcode` (deprecated, for pre-`barcodes` iOS) and `barcodes` (the full list Wallet actually reads). As of iOS 27, `barcodes` supports genuine fallback: pass more than one and Wallet picks the first format it supports, in order — e.g. an EAN13 barcode for iOS 27+ devices with a QR fallback for older ones:
+Under the hood the builder writes into both `barcode` (deprecated, for pre-`barcodes` iOS) and `barcodes` (the full list Wallet actually reads). As of iOS 27, `barcodes` supports genuine fallback: pass more than one and Wallet picks the first format it supports, in order — e.g. a PDF417 barcode for iOS 27+ devices with a QR fallback for older ones:
 
 ```php
 $builder
-    ->addBarcode(BarcodeType::Ean13, '4006381333931')
+    ->addBarcode(BarcodeType::Pdf417, '4006381333931')
     ->addBarcode(BarcodeType::Qr, 'TICKET-12345');
 ```
 

--- a/docs/basic-usage/adding-barcodes.md
+++ b/docs/basic-usage/adding-barcodes.md
@@ -35,15 +35,19 @@ $builder->setBarcode(
 );
 ```
 
-Under the hood the builder writes into both `barcode` (deprecated, for pre-`barcodes` iOS) and `barcodes` (the full list Wallet actually reads). As of iOS 27, `barcodes` supports genuine fallback: pass more than one and Wallet picks the first format it supports, in order — e.g. a PDF417 barcode for iOS 27+ devices with a QR fallback for older ones:
+Under the hood the builder writes into both `barcode` (deprecated, read by iOS 8 and earlier) and `barcodes` (the list every current version of Wallet reads).
+
+That list is ordered. Wallet renders the first format the device supports and ignores the rest, so you can offer a preferred format with a fallback behind it. Use `addBarcode()` to append instead of replace:
 
 ```php
 $builder
-    ->addBarcode(BarcodeType::Pdf417, '4006381333931')
+    ->addBarcode(BarcodeType::Pdf417, 'TICKET-12345')
     ->addBarcode(BarcodeType::Qr, 'TICKET-12345');
 ```
 
-`addBarcode()` appends to the list; `setBarcode()` still replaces it entirely with a single barcode, exactly as before. The deprecated singular `barcode` key is always populated from the *last* entry in the list — the most broadly-compatible format, for the oldest devices that only read that key.
+Devices that can render PDF417 use it, the rest fall back to the QR code.
+
+Calling `setBarcode()` still replaces the whole list with one barcode, exactly as before, so passes built with a single call are unaffected. The deprecated singular `barcode` key gets the last entry in the list, on the assumption that you ordered it preferred first and most broadly compatible last.
 
 ## Google
 

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -70,7 +70,8 @@ abstract class ApplePassBuilder
 
     protected ?string $downloadName = null;
 
-    protected ?Barcode $barcode = null;
+    /** @var array<int, Barcode> */
+    protected array $barcodes = [];
 
     protected ?Carbon $relevantDate = null;
 
@@ -417,15 +418,28 @@ abstract class ApplePassBuilder
 
     public function setBarcode(BarcodeType $format, string $message, ?string $altText = null): static
     {
+        $this->barcodes = [$this->buildBarcode($format, $message, $altText)];
+
+        return $this;
+    }
+
+    /** Appends a barcode to the pass's ordered barcode list, without clearing any barcodes already set. */
+    public function addBarcode(BarcodeType $format, string $message, ?string $altText = null): self
+    {
+        $this->barcodes[] = $this->buildBarcode($format, $message, $altText);
+
+        return $this;
+    }
+
+    private function buildBarcode(BarcodeType $format, string $message, ?string $altText): Barcode
+    {
         $barcode = Barcode::make($format, $message);
 
         if ($altText !== null) {
             $barcode->withAltText($altText);
         }
 
-        $this->barcode = $barcode;
-
-        return $this;
+        return $barcode;
     }
 
     public function setWifiBarcode(
@@ -723,7 +737,10 @@ abstract class ApplePassBuilder
 
     protected function compileData(): array
     {
-        $barcode = $this->barcode?->toArray();
+        $barcodes = empty($this->barcodes) ? null : array_map(
+            fn (Barcode $barcode) => $barcode->toArray(),
+            $this->barcodes,
+        );
 
         return array_merge($this->data, array_filter([
             'formatVersion' => 1,
@@ -738,8 +755,8 @@ abstract class ApplePassBuilder
             'backgroundColor' => (string) $this->backgroundColor,
             'foregroundColor' => (string) $this->foregroundColor,
             'labelColor' => (string) $this->labelColor,
-            'barcode' => $barcode,
-            'barcodes' => $barcode ? [$barcode] : null,
+            'barcode' => $barcodes ? $barcodes[array_key_last($barcodes)] : null,
+            'barcodes' => $barcodes,
             'relevantDate' => $this->relevantDate?->toIso8601String(),
             'locations' => empty($this->locations) ? null : array_map(
                 fn (Location $location) => $location->toArray(),
@@ -826,9 +843,9 @@ abstract class ApplePassBuilder
         $this->foregroundColor = Color::makeFromRgbString($this->data['foregroundColor'] ?? null);
         $this->labelColor = Color::makeFromRgbString($this->data['labelColor'] ?? null);
 
-        $this->barcode = empty($this->data['barcode'])
-            ? null
-            : Barcode::fromArray($this->data['barcode']);
+        $this->barcodes = ! empty($this->data['barcodes'])
+            ? array_map(fn (array $barcode) => Barcode::fromArray($barcode), $this->data['barcodes'])
+            : (empty($this->data['barcode']) ? [] : [Barcode::fromArray($this->data['barcode'])]);
 
         $this->relevantDate = empty($this->data['relevantDate'])
             ? null

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -431,7 +431,7 @@ abstract class ApplePassBuilder
         return $this;
     }
 
-    private function buildBarcode(BarcodeType $format, string $message, ?string $altText): Barcode
+    protected function buildBarcode(BarcodeType $format, string $message, ?string $altText): Barcode
     {
         $barcode = Barcode::make($format, $message);
 

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelMobilePass\Builders\Apple;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -423,7 +424,7 @@ abstract class ApplePassBuilder
         return $this;
     }
 
-    /** Appends a barcode to the pass's ordered barcode list, without clearing any barcodes already set. */
+    /** Appends a barcode to the pass, keeping any barcodes already set. */
     public function addBarcode(BarcodeType $format, string $message, ?string $altText = null): self
     {
         $this->barcodes[] = $this->buildBarcode($format, $message, $altText);
@@ -755,7 +756,7 @@ abstract class ApplePassBuilder
             'backgroundColor' => (string) $this->backgroundColor,
             'foregroundColor' => (string) $this->foregroundColor,
             'labelColor' => (string) $this->labelColor,
-            'barcode' => $barcodes ? $barcodes[array_key_last($barcodes)] : null,
+            'barcode' => $barcodes === null ? null : Arr::last($barcodes),
             'barcodes' => $barcodes,
             'relevantDate' => $this->relevantDate?->toIso8601String(),
             'locations' => empty($this->locations) ? null : array_map(
@@ -831,6 +832,23 @@ abstract class ApplePassBuilder
         return Carbon::parse($semantics[$key]);
     }
 
+    /** @return array<int, Barcode> */
+    protected function uncompileBarcodes(): array
+    {
+        if (! empty($this->data['barcodes'])) {
+            return array_map(
+                fn (array $barcode) => Barcode::fromArray($barcode),
+                $this->data['barcodes'],
+            );
+        }
+
+        if (empty($this->data['barcode'])) {
+            return [];
+        }
+
+        return [Barcode::fromArray($this->data['barcode'])];
+    }
+
     protected function uncompileContent(): void
     {
         $this->organizationName = $this->data['organizationName'] ?? null;
@@ -843,9 +861,7 @@ abstract class ApplePassBuilder
         $this->foregroundColor = Color::makeFromRgbString($this->data['foregroundColor'] ?? null);
         $this->labelColor = Color::makeFromRgbString($this->data['labelColor'] ?? null);
 
-        $this->barcodes = ! empty($this->data['barcodes'])
-            ? array_map(fn (array $barcode) => Barcode::fromArray($barcode), $this->data['barcodes'])
-            : (empty($this->data['barcode']) ? [] : [Barcode::fromArray($this->data['barcode'])]);
+        $this->barcodes = $this->uncompileBarcodes();
 
         $this->relevantDate = empty($this->data['relevantDate'])
             ? null

--- a/src/Builders/Apple/Entities/Barcode.php
+++ b/src/Builders/Apple/Entities/Barcode.php
@@ -4,6 +4,7 @@ namespace Spatie\LaravelMobilePass\Builders\Apple\Entities;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Spatie\LaravelMobilePass\Enums\BarcodeType;
+use Spatie\LaravelMobilePass\Exceptions\InvalidConfig;
 
 class Barcode implements Arrayable
 {
@@ -23,8 +24,14 @@ class Barcode implements Arrayable
     /** @param  array<string, mixed>  $fields */
     public static function fromArray(array $fields): self
     {
+        $format = BarcodeType::tryFrom($fields['format']);
+
+        if ($format === null) {
+            throw InvalidConfig::unrecognizedBarcodeFormat($fields['format']);
+        }
+
         $barcode = new self(
-            BarcodeType::tryFrom($fields['format']),
+            $format,
             $fields['message'],
             $fields['messageEncoding'],
         );

--- a/src/Exceptions/InvalidConfig.php
+++ b/src/Exceptions/InvalidConfig.php
@@ -54,4 +54,13 @@ class InvalidConfig extends Exception implements MobilePassException
             .'Leave the value empty if you do not need device registrations (typical for local dev over http://).'
         );
     }
+
+    public static function unrecognizedBarcodeFormat(string $format): self
+    {
+        return new self(
+            "The stored barcode format `{$format}` is not a recognized `BarcodeType` case. "
+            .'This can happen when a pass was saved by a newer version of the package that '
+            .'supports a barcode format this version does not yet know about.'
+        );
+    }
 }

--- a/tests/Builders/Apple/MultipleBarcodesTest.php
+++ b/tests/Builders/Apple/MultipleBarcodesTest.php
@@ -9,14 +9,14 @@ it('appends barcodes in call order via addBarcode', function () {
         ->setOrganizationName('Fab Four Promotions')
         ->setSerialNumber('BTL-SHEA-0042')
         ->setDescription('The Beatles at Shea Stadium')
-        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Pdf417, '4006381333931')
         ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
         ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
         ->data();
 
     expect($data['barcodes'])->toHaveCount(2);
     expect($data['barcodes'][0])->toMatchArray([
-        'format' => 'PKBarcodeFormatEAN13',
+        'format' => 'PKBarcodeFormatPDF417',
         'message' => '4006381333931',
     ]);
     expect($data['barcodes'][1])->toMatchArray([
@@ -30,7 +30,7 @@ it('populates the deprecated barcode key with the last entry', function () {
         ->setOrganizationName('Fab Four Promotions')
         ->setSerialNumber('BTL-SHEA-0042')
         ->setDescription('The Beatles at Shea Stadium')
-        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Pdf417, '4006381333931')
         ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
         ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
         ->data();
@@ -46,7 +46,7 @@ it('resets to a single entry when setBarcode is called after addBarcode', functi
         ->setOrganizationName('Fab Four Promotions')
         ->setSerialNumber('BTL-SHEA-0042')
         ->setDescription('The Beatles at Shea Stadium')
-        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Pdf417, '4006381333931')
         ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
         ->setBarcode(BarcodeType::Aztec, 'TICKET-99999')
         ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
@@ -84,7 +84,7 @@ it('round-trips multiple barcodes through save and hydrate, preserving order', f
         ->setOrganizationName('Fab Four Promotions')
         ->setSerialNumber('BTL-SHEA-0042')
         ->setDescription('The Beatles at Shea Stadium')
-        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Pdf417, '4006381333931')
         ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
         ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
         ->save();
@@ -92,7 +92,7 @@ it('round-trips multiple barcodes through save and hydrate, preserving order', f
     $data = EventTicketPassBuilder::hydrate($model)->data();
 
     expect($data['barcodes'])->toHaveCount(2);
-    expect($data['barcodes'][0]['format'])->toBe('PKBarcodeFormatEAN13');
+    expect($data['barcodes'][0]['format'])->toBe('PKBarcodeFormatPDF417');
     expect($data['barcodes'][1]['format'])->toBe('PKBarcodeFormatQR');
 });
 
@@ -128,4 +128,16 @@ it('omits barcode and barcodes when none are set', function () {
 
     expect($data)->not->toHaveKey('barcode');
     expect($data)->not->toHaveKey('barcodes');
+});
+
+it('sets altText on a barcode added via addBarcode', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addBarcode(BarcodeType::Qr, 'TICKET-12345', altText: 'Show this at the gate')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data['barcodes'][0]['altText'])->toBe('Show this at the gate');
 });

--- a/tests/Builders/Apple/MultipleBarcodesTest.php
+++ b/tests/Builders/Apple/MultipleBarcodesTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\EventTicketPassBuilder;
+use Spatie\LaravelMobilePass\Enums\BarcodeType;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+it('appends barcodes in call order via addBarcode', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data['barcodes'])->toHaveCount(2);
+    expect($data['barcodes'][0])->toMatchArray([
+        'format' => 'PKBarcodeFormatEAN13',
+        'message' => '4006381333931',
+    ]);
+    expect($data['barcodes'][1])->toMatchArray([
+        'format' => 'PKBarcodeFormatQR',
+        'message' => 'TICKET-12345',
+    ]);
+});
+
+it('populates the deprecated barcode key with the last entry', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data['barcode'])->toMatchArray([
+        'format' => 'PKBarcodeFormatQR',
+        'message' => 'TICKET-12345',
+    ]);
+});
+
+it('resets to a single entry when setBarcode is called after addBarcode', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
+        ->setBarcode(BarcodeType::Aztec, 'TICKET-99999')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data['barcodes'])->toHaveCount(1);
+    expect($data['barcodes'][0])->toMatchArray([
+        'format' => 'PKBarcodeFormatAztec',
+        'message' => 'TICKET-99999',
+    ]);
+    expect($data['barcode'])->toMatchArray([
+        'format' => 'PKBarcodeFormatAztec',
+        'message' => 'TICKET-99999',
+    ]);
+});
+
+it('behaves like setBarcode when addBarcode is called with nothing set before it', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data['barcodes'])->toHaveCount(1);
+    expect($data['barcode'])->toMatchArray([
+        'format' => 'PKBarcodeFormatQR',
+        'message' => 'TICKET-12345',
+    ]);
+});
+
+it('round-trips multiple barcodes through save and hydrate, preserving order', function () {
+    $model = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addBarcode(BarcodeType::Ean13, '4006381333931')
+        ->addBarcode(BarcodeType::Qr, 'TICKET-12345')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->save();
+
+    $data = EventTicketPassBuilder::hydrate($model)->data();
+
+    expect($data['barcodes'])->toHaveCount(2);
+    expect($data['barcodes'][0]['format'])->toBe('PKBarcodeFormatEAN13');
+    expect($data['barcodes'][1]['format'])->toBe('PKBarcodeFormatQR');
+});
+
+it('hydrates a legacy row with only a singular barcode key into a one-element list', function () {
+    $model = MobilePass::factory()->make([
+        'builder_name' => EventTicketPassBuilder::name(),
+        'content' => [
+            'organizationName' => 'Fab Four Promotions',
+            'serialNumber' => 'BTL-SHEA-0042',
+            'description' => 'The Beatles at Shea Stadium',
+            'barcode' => [
+                'format' => 'PKBarcodeFormatQR',
+                'message' => 'TICKET-12345',
+                'messageEncoding' => 'iso-8859-1',
+            ],
+        ],
+    ]);
+
+    $data = EventTicketPassBuilder::hydrate($model)->data();
+
+    expect($data['barcodes'])->toHaveCount(1);
+    expect($data['barcodes'][0]['format'])->toBe('PKBarcodeFormatQR');
+    expect($data['barcode']['format'])->toBe('PKBarcodeFormatQR');
+});
+
+it('omits barcode and barcodes when none are set', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data)->not->toHaveKey('barcode');
+    expect($data)->not->toHaveKey('barcodes');
+});

--- a/tests/Entities/BarcodeTest.php
+++ b/tests/Entities/BarcodeTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Barcode;
+use Spatie\LaravelMobilePass\Exceptions\InvalidConfig;
+
+it('throws a clear exception when hydrating an unrecognized barcode format', function () {
+    Barcode::fromArray([
+        'format' => 'PKBarcodeFormatFutureFormat',
+        'message' => 'TICKET-12345',
+        'messageEncoding' => 'iso-8859-1',
+    ]);
+})->throws(InvalidConfig::class, 'PKBarcodeFormatFutureFormat');


### PR DESCRIPTION
## What                                                                                                                                                                   
                                                                                                                                                                            
  As of iOS 27, Apple's Wallet Passes reference documents genuine multi-barcode fallback support in the `barcodes` array: order matters, first-to-last is  preferred-to-fallback, and Wallet renders the first format it supports. From Apple's own docs:                                                                            
                                                                                                                                                                            
  > "In iOS 27 and later, you can provide more than one barcode as a fallback. If you provide EAN 13 and QR formats in the barcodes array, the EAN 13 barcode renders on  devices using iOS 27 and later and the QR code renders for devices using pre-iOS 27."                                                                                     
                                                                                                                                                                            
  This package only ever supported one barcode — confirmed by code inspection: `ApplePassBuilder` had a single `?Barcode $barcode` property, `setBarcode()` overwrote it on  every call, and `compileData()` always wrapped it into a 1-element `barcodes` array.                                                                                      
                                                                                                                                                                            
  This PR adds a new `addBarcode()` method that appends to an ordered list, while `setBarcode()` keeps its exact original behavior (always replaces the whole list with one entry) — zero risk to any existing caller.                                                      
                                                                                                                                                                            
  ```php                                                                                                                                                                    
  $builder                                                                                                                                                                  
      ->addBarcode(BarcodeType::Pdf417, '4006381333931')                                                                                                                    
      ->addBarcode(BarcodeType::Qr, 'TICKET-12345');                                                                                                                        
  ```                                                                                                                                                                       
                                                                                                                                                                            
  ## Design decisions                                                                                                                                                       
                                                                                                                                                                            
  - **The deprecated singular `barcode` key gets the *last* entry**, not the first. That key is only read by pre-`barcodes` iOS — the oldest devices — so it should carry  the most broadly-compatible format in the list, not the newest-iOS-preferred one.                                                                                         
  - **`uncompileContent()` prefers the plural `barcodes` key when hydrating**, falling back to the deprecated singular key only for rows saved before this feature existed — so old rows hydrate cleanly into a one-element list and naturally upgrade to the dual-key format on next save.                                                            
 - **No Google-side changes.** `GooglePassBuilder` is a separate class hierarchy that only shares the `Barcode` entity and `BarcodeType` enum with `ApplePassBuilder`, not  the base class itself. It never had multi-barcode capability and Google's API has no iOS-version-fallback concept to support.                                             
 - **No validator changes.** `ApplePassValidator::rules()` already has pass-through entries for both `'barcode'` and `'barcodes'`.

  ## Also fixed: unrecognized stored barcode formats now fail clearly                                                                                                       
                                                                                                                                                                            
  `Barcode::fromArray()` passed `BarcodeType::tryFrom()`'s result straight into a non-nullable constructor parameter, so hydrating a row with an unrecognized `format`  string raised a generic `TypeError` ("must be of type BarcodeType, null given") instead of a message pointing at the actual problem. This was already possible before this.PR, but a multi-barcode pass makes it meaningfully more likely: a row written by a newer deploy (with a barcode format this version doesn't know about yet) hydrated by  an older one now has more than one chance to hit it. `Barcode::fromArray()` now throws a new `InvalidConfig::unrecognizedBarcodeFormat()` naming the actual bad format string.   
               
  ## Testing                                                                                                                                                                
                                                                                                                                                                            
  New `tests/Builders/Apple/MultipleBarcodesTest.php`: append order, deprecated-key-gets-last-entry, `setBarcode()` resets after `addBarcode()` calls, `addBarcode()` alone behaves like `setBarcode()`, save/hydrate round-trip preserving order, legacy-row hydration (only a singular `barcode` key present), omission when unset, and `altText` on an `addBarcode()`-added entry. `tests/Builders/Apple/WifiBarcodeTest.php` (existing) passes unmodified — regression guard that `setBarcode()`'s behavior is untouched.   Full suite passes.   