### PR TITLE
fix/feat: seat semantic tag wire keys

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,18 @@
 # Upgrading
 
+## Apple seat semantic tags now use Apple's wire keys
+
+`Seat` used to serialize its properties under bare keys (`number`, `row`, `section`, ...). Apple's
+`SemanticTagType.Seat` dictionary expects `seat`-prefixed keys (`seatNumber`, `seatRow`, `seatSection`, ...),
+so Wallet ignored the seat details this package wrote. They are now written under the keys Apple documents.
+
+No code changes are required. The property names on `Seat` are unchanged, the three new properties
+(`aisle`, `level` and `sectionColor`) were appended to the constructor so positional calls keep working,
+and passes stored before this release still hydrate: `Seat::fromArray()` reads the old bare keys as a
+fallback and rewrites them under the correct keys on the next save.
+
+If you assert on the raw `pass.json` in your own tests, note that the keys inside `semantics.seats` changed.
+
 ## Google Wallet i18n — LocalizedString for Loyalty and Offer pass classes
 
 `LoyaltyPassClass` and `OfferPassClass` now support per-locale translations.

--- a/docs/available-pass-types/boarding-pass.md
+++ b/docs/available-pass-types/boarding-pass.md
@@ -25,6 +25,8 @@ AirlinePassBuilder::make()
     ->save();
 ```
 
+Besides the `number` shown above, a `Seat` can carry a `description`, `identifier`, `row`, `section`, `type`, `aisle`, `level` and `sectionColor`. All of them are optional, and `setSeats()` accepts more than one `Seat`.
+
 For trains, `TrainPassBuilder` ships with the package and works exactly like `AirlinePassBuilder`:
 
 ```php

--- a/docs/available-pass-types/event-ticket.md
+++ b/docs/available-pass-types/event-ticket.md
@@ -93,6 +93,21 @@ EventTicketPassBuilder::make()
     ->save();
 ```
 
+A `Seat` carries the nine properties Apple defines: `description`, `identifier`, `number`, `row`, `section`, `type`, `aisle`, `level` and `sectionColor`. All of them are optional, so pass only the ones you have. The `sectionColor` is a CSS-style RGB triple.
+
+```php
+Seat::make(
+    number: '22',
+    row: '8',
+    section: 'B12',
+    aisle: 'A',
+    level: 'Lower Bowl',
+    sectionColor: 'rgb(23,187,82)',
+)
+```
+
+Pass several seats at once by giving `setSeats()` more than one `Seat`.
+
 ## Google
 
 Declare the Class once per event (the venue, the show, the shared visuals), then create an Object per ticket.

--- a/src/Builders/Apple/Entities/Seat.php
+++ b/src/Builders/Apple/Entities/Seat.php
@@ -7,38 +7,38 @@ use Illuminate\Contracts\Support\Arrayable;
 class Seat implements Arrayable
 {
     public function __construct(
-        public ?string $aisle,
-        public ?string $description,
-        public ?string $identifier,
-        public ?string $level,
-        public ?string $number,
-        public ?string $row,
-        public ?string $section,
-        public ?string $sectionColor,
-        public ?string $type,
+        public ?string $description = null,
+        public ?string $identifier = null,
+        public ?string $number = null,
+        public ?string $row = null,
+        public ?string $section = null,
+        public ?string $type = null,
+        public ?string $aisle = null,
+        public ?string $level = null,
+        public ?string $sectionColor = null,
     ) {}
 
     public static function make(
-        ?string $aisle = null,
         ?string $description = null,
         ?string $identifier = null,
-        ?string $level = null,
         ?string $number = null,
         ?string $row = null,
         ?string $section = null,
-        ?string $sectionColor = null,
         ?string $type = null,
+        ?string $aisle = null,
+        ?string $level = null,
+        ?string $sectionColor = null,
     ): self {
         return new self(
-            aisle: $aisle,
             description: $description,
             identifier: $identifier,
-            level: $level,
             number: $number,
             row: $row,
             section: $section,
-            sectionColor: $sectionColor,
             type: $type,
+            aisle: $aisle,
+            level: $level,
+            sectionColor: $sectionColor,
         );
     }
 
@@ -46,15 +46,15 @@ class Seat implements Arrayable
     public static function fromArray(array $values): self
     {
         return new self(
+            description: $values['seatDescription'] ?? $values['description'] ?? null,
+            identifier: $values['seatIdentifier'] ?? $values['identifier'] ?? null,
+            number: $values['seatNumber'] ?? $values['number'] ?? null,
+            row: $values['seatRow'] ?? $values['row'] ?? null,
+            section: $values['seatSection'] ?? $values['section'] ?? null,
+            type: $values['seatType'] ?? $values['type'] ?? null,
             aisle: $values['seatAisle'] ?? null,
-            description: $values['seatDescription'] ?? null,
-            identifier: $values['seatIdentifier'] ?? null,
             level: $values['seatLevel'] ?? null,
-            number: $values['seatNumber'] ?? null,
-            row: $values['seatRow'] ?? null,
-            section: $values['seatSection'] ?? null,
             sectionColor: $values['seatSectionColor'] ?? null,
-            type: $values['seatType'] ?? null,
         );
     }
 

--- a/src/Builders/Apple/Entities/Seat.php
+++ b/src/Builders/Apple/Entities/Seat.php
@@ -37,24 +37,24 @@ class Seat implements Arrayable
     public static function fromArray(array $values): self
     {
         return new self(
-            description: $values['description'] ?? null,
-            identifier: $values['identifier'] ?? null,
-            number: $values['number'] ?? null,
-            row: $values['row'] ?? null,
-            section: $values['section'] ?? null,
-            type: $values['type'] ?? null,
+            description: $values['seatDescription'] ?? null,
+            identifier: $values['seatIdentifier'] ?? null,
+            number: $values['seatNumber'] ?? null,
+            row: $values['seatRow'] ?? null,
+            section: $values['seatSection'] ?? null,
+            type: $values['seatType'] ?? null,
         );
     }
 
     public function toArray(): array
     {
         return array_filter([
-            'description' => $this->description,
-            'identifier' => $this->identifier,
-            'number' => $this->number,
-            'row' => $this->row,
-            'section' => $this->section,
-            'type' => $this->type,
+            'seatDescription' => $this->description,
+            'seatIdentifier' => $this->identifier,
+            'seatNumber' => $this->number,
+            'seatRow' => $this->row,
+            'seatSection' => $this->section,
+            'seatType' => $this->type,
         ], fn ($value) => $value !== null);
     }
 }

--- a/src/Builders/Apple/Entities/Seat.php
+++ b/src/Builders/Apple/Entities/Seat.php
@@ -7,28 +7,37 @@ use Illuminate\Contracts\Support\Arrayable;
 class Seat implements Arrayable
 {
     public function __construct(
+        public ?string $aisle,
         public ?string $description,
         public ?string $identifier,
+        public ?string $level,
         public ?string $number,
         public ?string $row,
         public ?string $section,
+        public ?string $sectionColor,
         public ?string $type,
     ) {}
 
     public static function make(
+        ?string $aisle = null,
         ?string $description = null,
         ?string $identifier = null,
+        ?string $level = null,
         ?string $number = null,
         ?string $row = null,
         ?string $section = null,
+        ?string $sectionColor = null,
         ?string $type = null,
     ): self {
         return new self(
+            aisle: $aisle,
             description: $description,
             identifier: $identifier,
+            level: $level,
             number: $number,
             row: $row,
             section: $section,
+            sectionColor: $sectionColor,
             type: $type,
         );
     }
@@ -37,11 +46,14 @@ class Seat implements Arrayable
     public static function fromArray(array $values): self
     {
         return new self(
+            aisle: $values['seatAisle'] ?? null,
             description: $values['seatDescription'] ?? null,
             identifier: $values['seatIdentifier'] ?? null,
+            level: $values['seatLevel'] ?? null,
             number: $values['seatNumber'] ?? null,
             row: $values['seatRow'] ?? null,
             section: $values['seatSection'] ?? null,
+            sectionColor: $values['seatSectionColor'] ?? null,
             type: $values['seatType'] ?? null,
         );
     }
@@ -49,11 +61,14 @@ class Seat implements Arrayable
     public function toArray(): array
     {
         return array_filter([
+            'seatAisle' => $this->aisle,
             'seatDescription' => $this->description,
             'seatIdentifier' => $this->identifier,
+            'seatLevel' => $this->level,
             'seatNumber' => $this->number,
             'seatRow' => $this->row,
             'seatSection' => $this->section,
+            'seatSectionColor' => $this->sectionColor,
             'seatType' => $this->type,
         ], fn ($value) => $value !== null);
     }

--- a/tests/.pest/snapshots/Builders/Apple/AirlinePassBuilderTest/it_builds_a_basic_airline_boarding_pass.snap
+++ b/tests/.pest/snapshots/Builders/Apple/AirlinePassBuilderTest/it_builds_a_basic_airline_boarding_pass.snap
@@ -21,7 +21,7 @@
             "destinationLocationDescription": "Abu Dhabi Intl",
             "seats": [
                 {
-                    "number": "66F"
+                    "seatNumber": "66F"
                 }
             ],
             "departureAirportCode": "AUH",

--- a/tests/.pest/snapshots/Builders/Apple/AirlinePassBuilderTest/it_builds_a_basic_airline_boarding_pass__2.snap
+++ b/tests/.pest/snapshots/Builders/Apple/AirlinePassBuilderTest/it_builds_a_basic_airline_boarding_pass__2.snap
@@ -21,7 +21,7 @@
             "destinationLocationDescription": "Abu Dhabi Intl",
             "seats": [
                 {
-                    "number": "123DAN"
+                    "seatNumber": "123DAN"
                 }
             ],
             "departureAirportCode": "AUH",

--- a/tests/.pest/snapshots/Builders/Apple/TrainPassBuilderTest/it_builds_a_basic_train_pass.snap
+++ b/tests/.pest/snapshots/Builders/Apple/TrainPassBuilderTest/it_builds_a_basic_train_pass.snap
@@ -23,7 +23,7 @@
             },
             "seats": [
                 {
-                    "number": "24B"
+                    "seatNumber": "24B"
                 }
             ],
             "carNumber": "3",

--- a/tests/Builders/Apple/EventTicketPassBuilderTest.php
+++ b/tests/Builders/Apple/EventTicketPassBuilderTest.php
@@ -335,7 +335,14 @@ function builderWithEveryEventDetail(): EventTicketPassBuilder
         ->setLeagueAbbreviation('MLB')
         ->setLeagueName('Major League Baseball')
         ->setSportName('Baseball')
-        ->setSeats(Seat::make(number: '22', row: '8', section: 'B12'));
+        ->setSeats(Seat::make(
+            aisle: 'A',
+            number: '22',
+            level: 'Lower Bowl',
+            row: '8',
+            section: 'B12',
+            sectionColor: 'rgb(23,187,82)',
+        ));
 }
 
 function expectedEventDetailSemantics(): array
@@ -375,7 +382,14 @@ function expectedEventDetailSemantics(): array
         'leagueName' => 'Major League Baseball',
         'sportName' => 'Baseball',
         'seats' => [
-            ['seatNumber' => '22', 'seatRow' => '8', 'seatSection' => 'B12'],
+            [
+                'seatAisle' => 'A',
+                'seatLevel' => 'Lower Bowl',
+                'seatNumber' => '22',
+                'seatRow' => '8',
+                'seatSection' => 'B12',
+                'seatSectionColor' => 'rgb(23,187,82)',
+            ],
         ],
     ];
 }

--- a/tests/Builders/Apple/EventTicketPassBuilderTest.php
+++ b/tests/Builders/Apple/EventTicketPassBuilderTest.php
@@ -375,7 +375,7 @@ function expectedEventDetailSemantics(): array
         'leagueName' => 'Major League Baseball',
         'sportName' => 'Baseball',
         'seats' => [
-            ['number' => '22', 'row' => '8', 'section' => 'B12'],
+            ['seatNumber' => '22', 'seatRow' => '8', 'seatSection' => 'B12'],
         ],
     ];
 }

--- a/tests/Builders/Apple/SeatSemanticsTest.php
+++ b/tests/Builders/Apple/SeatSemanticsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Seat;
+use Spatie\LaravelMobilePass\Builders\Apple\EventTicketPassBuilder;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+it('round-trips seats through save and hydrate', function () {
+    $model = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->setSeats(Seat::make(
+            number: '22',
+            row: '8',
+            section: 'B12',
+            aisle: 'A',
+            level: 'Lower Bowl',
+            sectionColor: 'rgb(23,187,82)',
+        ))
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->save();
+
+    $data = EventTicketPassBuilder::hydrate($model)->data();
+
+    expect($data['semantics']['seats'])->toBe([
+        [
+            'seatAisle' => 'A',
+            'seatLevel' => 'Lower Bowl',
+            'seatNumber' => '22',
+            'seatRow' => '8',
+            'seatSection' => 'B12',
+            'seatSectionColor' => 'rgb(23,187,82)',
+        ],
+    ]);
+});
+
+it('hydrates a legacy row that stored seats under the bare keys', function () {
+    $model = MobilePass::factory()->make([
+        'builder_name' => EventTicketPassBuilder::name(),
+        'content' => [
+            'organizationName' => 'Fab Four Promotions',
+            'serialNumber' => 'BTL-SHEA-0042',
+            'description' => 'The Beatles at Shea Stadium',
+            'semantics' => [
+                'seats' => [
+                    ['number' => '22', 'row' => '8', 'section' => 'B12'],
+                ],
+            ],
+        ],
+    ]);
+
+    $data = EventTicketPassBuilder::hydrate($model)->data();
+
+    expect($data['semantics']['seats'])->toBe([
+        [
+            'seatNumber' => '22',
+            'seatRow' => '8',
+            'seatSection' => 'B12',
+        ],
+    ]);
+});

--- a/tests/Entities/SeatTest.php
+++ b/tests/Entities/SeatTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Seat;
+
+it('serializes every property to its apple wire key', function () {
+    $seat = Seat::make(
+        description: 'Aisle seat with extra legroom',
+        identifier: 'SEAT-22',
+        number: '22',
+        row: '8',
+        section: 'B12',
+        type: 'Reserved',
+        aisle: 'A',
+        level: 'Lower Bowl',
+        sectionColor: 'rgb(23,187,82)',
+    );
+
+    expect($seat->toArray())->toBe([
+        'seatAisle' => 'A',
+        'seatDescription' => 'Aisle seat with extra legroom',
+        'seatIdentifier' => 'SEAT-22',
+        'seatLevel' => 'Lower Bowl',
+        'seatNumber' => '22',
+        'seatRow' => '8',
+        'seatSection' => 'B12',
+        'seatSectionColor' => 'rgb(23,187,82)',
+        'seatType' => 'Reserved',
+    ]);
+});
+
+it('round-trips through the apple wire keys', function () {
+    $values = [
+        'seatAisle' => 'A',
+        'seatDescription' => 'Aisle seat with extra legroom',
+        'seatIdentifier' => 'SEAT-22',
+        'seatLevel' => 'Lower Bowl',
+        'seatNumber' => '22',
+        'seatRow' => '8',
+        'seatSection' => 'B12',
+        'seatSectionColor' => 'rgb(23,187,82)',
+        'seatType' => 'Reserved',
+    ];
+
+    expect(Seat::fromArray($values)->toArray())->toBe($values);
+});
+
+it('hydrates the bare keys written before the wire keys were corrected', function () {
+    $seat = Seat::fromArray([
+        'description' => 'Aisle seat with extra legroom',
+        'identifier' => 'SEAT-22',
+        'number' => '22',
+        'row' => '8',
+        'section' => 'B12',
+        'type' => 'Reserved',
+    ]);
+
+    expect($seat->toArray())->toBe([
+        'seatDescription' => 'Aisle seat with extra legroom',
+        'seatIdentifier' => 'SEAT-22',
+        'seatNumber' => '22',
+        'seatRow' => '8',
+        'seatSection' => 'B12',
+        'seatType' => 'Reserved',
+    ]);
+});
+
+it('prefers the wire key when a bare key is present alongside it', function () {
+    $seat = Seat::fromArray([
+        'seatNumber' => '22',
+        'number' => '99',
+    ]);
+
+    expect($seat->number)->toBe('22');
+});
+
+it('keeps the original positional argument order', function () {
+    $seat = new Seat('Aisle seat with extra legroom', 'SEAT-22', '22', '8', 'B12', 'Reserved');
+
+    expect($seat->description)->toBe('Aisle seat with extra legroom');
+    expect($seat->identifier)->toBe('SEAT-22');
+    expect($seat->number)->toBe('22');
+    expect($seat->row)->toBe('8');
+    expect($seat->section)->toBe('B12');
+    expect($seat->type)->toBe('Reserved');
+    expect($seat->aisle)->toBeNull();
+    expect($seat->level)->toBeNull();
+    expect($seat->sectionColor)->toBeNull();
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                         
  - The `Seat` entity was serializing/parsing seat details with bare keys (`number`, `row`, `section`, ...) instead of the `seat`-prefixed wire keys Apple's PassKit  `SemanticTagType.Seat` actually requires (`seatNumber`, `seatRow`, `seatSection`, ...), so seat data was silently dropped by Wallet.                                               
  - While auditing against Apple's spec, found we were also missing 3 of the 9 documented properties: `seatAisle`, `seatLevel`, and `seatSectionColor`. Added them.                  
                                                                                                                                                                                     
  ## Changes                                                                                                                                                                         
  - `src/Builders/Apple/Entities/Seat.php`: corrected wire keys in `toArray()`/`fromArray()`, and added `aisle`, `level`, `sectionColor` fields.                                     
  - Updated affected test expectations and snapshot fixtures (`AirlinePassBuilderTest`, `TrainPassBuilderTest`, `EventTicketPassBuilderTest`) to match the corrected/expanded wire   format.                                                                                                                                                                            
                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                       
  - [x] Full test suite run locally (all passing)                                                                                                                                    
  - [x] Verified all callers use named arguments, so the new constructor params are non-breaking      