### PR TITLE
fix: include nameSuffix when serializing PersonName

### DIFF
--- a/src/Builders/Apple/Entities/PersonName.php
+++ b/src/Builders/Apple/Entities/PersonName.php
@@ -57,6 +57,7 @@ class PersonName implements Arrayable
             'givenName' => $this->givenName,
             'middleName' => $this->middleName,
             'namePrefix' => $this->namePrefix,
+            'nameSuffix' => $this->nameSuffix,
             'nickname' => $this->nickname,
             'phoneticRepresentation' => $this->phoneticRepresentation,
         ], fn ($value) => $value !== null);

--- a/tests/Entities/PersonNameTest.php
+++ b/tests/Entities/PersonNameTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\PersonName;
+
+it('serializes every property, including the name suffix', function () {
+    $personName = PersonName::make(
+        familyName: 'Harrison',
+        givenName: 'George',
+        middleName: 'Harold',
+        namePrefix: 'Mr.',
+        nameSuffix: 'Jr.',
+        nickname: 'The Quiet One',
+        phoneticRepresentation: 'jɔːrdʒ ˈhærɪsən',
+    );
+
+    expect($personName->toArray())->toBe([
+        'familyName' => 'Harrison',
+        'givenName' => 'George',
+        'middleName' => 'Harold',
+        'namePrefix' => 'Mr.',
+        'nameSuffix' => 'Jr.',
+        'nickname' => 'The Quiet One',
+        'phoneticRepresentation' => 'jɔːrdʒ ˈhærɪsən',
+    ]);
+});
+
+it('hydrates the name suffix from an array', function () {
+    $personName = PersonName::fromArray([
+        'nameSuffix' => 'Jr.',
+    ]);
+
+    expect($personName->nameSuffix)->toBe('Jr.');
+    expect($personName->toArray())->toBe(['nameSuffix' => 'Jr.']);
+});


### PR DESCRIPTION
  ## Summary                                                                                                                                                                         
  - `PersonName::toArray()` was missing `nameSuffix` — the constructor, `make()`, and `fromArray()` all support it, but it was silently dropped when compiling the pass, so it never reached Wallet.                                                                                                                                                                    
                                                                                                                                                                                     
  ## Changes                                                                                                                                                                         
  - `src/Builders/Apple/Entities/PersonName.php`: add `nameSuffix` to `toArray()`.                                                                                                   
  - `tests/Entities/PersonNameTest.php`: new regression tests covering full round-trip serialization, including `nameSuffix`.                                                        

## Test plan

- [x] Full test suite run locally (all passing)
                                               