### PR TITLE
feat: add Pass.RelevantDates support to Apple passes

### DIFF
--- a/docs/apple-wallet/pass-relevance.md
+++ b/docs/apple-wallet/pass-relevance.md
@@ -21,6 +21,23 @@ $builder->setRelevantDate(Carbon::parse('2026-08-15 20:00', 'America/New_York'))
 
 When the user's device crosses into that window, the pass slides onto the lock screen. Once the event has passed, the pass drops back out of relevance.
 
+## Relevant date intervals
+
+`setRelevantDate()` covers most cases, but iOS 18+ lets you attach several relevance windows to a single pass via `Pass.RelevantDates`. Add as many as you need with `addRelevantDate()` (Apple calculates the window around a single moment, same as `setRelevantDate()`) and `addRelevantDateInterval()` (an explicit start and end):
+
+```php
+use Illuminate\Support\Carbon;
+
+$builder
+    ->addRelevantDate(Carbon::parse('2026-08-15 20:00', 'America/New_York'))
+    ->addRelevantDateInterval(
+        Carbon::parse('2026-08-15 18:00', 'America/New_York'),
+        Carbon::parse('2026-08-15 23:00', 'America/New_York'),
+    );
+```
+
+This is additive to `setRelevantDate()` — set either, both, or neither depending on which iOS versions and relevance shapes your pass needs.
+
 ## Locations
 
 Attach one or more physical locations and Wallet will bring the pass forward when the user is near one of them. Latitude and longitude are all you have to provide:

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -16,6 +16,7 @@ use Spatie\LaravelMobilePass\Builders\Apple\Entities\Image;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Location;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\NfcPayload;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Price;
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\RelevantDate;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\WifiNetwork;
 use Spatie\LaravelMobilePass\Builders\Apple\Validators\ApplePassValidator;
 use Spatie\LaravelMobilePass\Enums\BarcodeType;
@@ -77,6 +78,9 @@ abstract class ApplePassBuilder
     protected array $barcodes = [];
 
     protected ?Carbon $relevantDate = null;
+
+    /** @var array<int, RelevantDate> */
+    protected array $relevantDates = [];
 
     protected ?int $maxDistance = null;
 
@@ -473,6 +477,20 @@ abstract class ApplePassBuilder
         return $this;
     }
 
+    public function addRelevantDate(Carbon $date): static
+    {
+        $this->relevantDates[] = new RelevantDate(date: $date);
+
+        return $this;
+    }
+
+    public function addRelevantDateInterval(Carbon $startDate, Carbon $endDate): static
+    {
+        $this->relevantDates[] = new RelevantDate(startDate: $startDate, endDate: $endDate);
+
+        return $this;
+    }
+
     public function addLocation(
         float $latitude,
         float $longitude,
@@ -770,6 +788,10 @@ abstract class ApplePassBuilder
             'barcode' => $barcodes === null ? null : Arr::last($barcodes),
             'barcodes' => $barcodes,
             'relevantDate' => $this->relevantDate?->toIso8601String(),
+            'relevantDates' => empty($this->relevantDates) ? null : array_map(
+                fn (RelevantDate $relevantDate) => $relevantDate->toArray(),
+                $this->relevantDates,
+            ),
             'locations' => empty($this->locations) ? null : array_map(
                 fn (Location $location) => $location->toArray(),
                 $this->locations,
@@ -878,6 +900,11 @@ abstract class ApplePassBuilder
         $this->relevantDate = empty($this->data['relevantDate'])
             ? null
             : Carbon::parse($this->data['relevantDate']);
+
+        $this->relevantDates = array_map(
+            fn (array $relevantDate) => RelevantDate::fromArray($relevantDate),
+            $this->data['relevantDates'] ?? [],
+        );
 
         $this->locations = array_map(
             fn (array $location) => Location::fromArray($location),

--- a/src/Builders/Apple/Entities/RelevantDate.php
+++ b/src/Builders/Apple/Entities/RelevantDate.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Builders\Apple\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Carbon;
+
+class RelevantDate implements Arrayable
+{
+    public function __construct(
+        public ?Carbon $date = null,
+        public ?Carbon $startDate = null,
+        public ?Carbon $endDate = null,
+    ) {}
+
+    public static function make(
+        ?Carbon $date = null,
+        ?Carbon $startDate = null,
+        ?Carbon $endDate = null,
+    ): self {
+        return new self($date, $startDate, $endDate);
+    }
+
+    /** @param  array<string, mixed>  $values */
+    public static function fromArray(array $values): self
+    {
+        return new self(
+            isset($values['date']) ? Carbon::parse($values['date']) : null,
+            isset($values['startDate']) ? Carbon::parse($values['startDate']) : null,
+            isset($values['endDate']) ? Carbon::parse($values['endDate']) : null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'date' => $this->date?->toIso8601String(),
+            'startDate' => $this->startDate?->toIso8601String(),
+            'endDate' => $this->endDate?->toIso8601String(),
+        ], fn ($value) => $value !== null);
+    }
+}

--- a/src/Builders/Apple/Validators/ApplePassValidator.php
+++ b/src/Builders/Apple/Validators/ApplePassValidator.php
@@ -22,6 +22,7 @@ abstract class ApplePassValidator
             'barcode' => [],
             'barcodes' => [],
             'relevantDate' => [],
+            'relevantDates' => [],
             'locations' => [],
             'maxDistance' => [],
             'beacons' => [],

--- a/tests/Builders/Apple/RelevanceTest.php
+++ b/tests/Builders/Apple/RelevanceTest.php
@@ -17,6 +17,50 @@ it('serialises a relevant date onto the pass', function () {
     expect($data['relevantDate'])->toStartWith('1965-08-15T20:00:00');
 });
 
+it('serialises relevant date intervals onto the pass', function () {
+    $data = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Promotions')
+        ->setSerialNumber('BTL-SHEA-0042')
+        ->setDescription('The Beatles at Shea Stadium')
+        ->addRelevantDate(Carbon::parse('1965-08-15 20:00', 'America/New_York'))
+        ->addRelevantDateInterval(
+            Carbon::parse('1965-08-15 18:00', 'America/New_York'),
+            Carbon::parse('1965-08-15 23:00', 'America/New_York'),
+        )
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->data();
+
+    expect($data)->toHaveKey('relevantDates');
+    expect($data['relevantDates'])->toHaveCount(2);
+    expect($data['relevantDates'][0]['date'])->toStartWith('1965-08-15T20:00:00');
+    expect($data['relevantDates'][0])->not->toHaveKeys(['startDate', 'endDate']);
+    expect($data['relevantDates'][1]['startDate'])->toStartWith('1965-08-15T18:00:00');
+    expect($data['relevantDates'][1]['endDate'])->toStartWith('1965-08-15T23:00:00');
+    expect($data['relevantDates'][1])->not->toHaveKey('date');
+});
+
+it('round-trips relevant date intervals through the uncompile path', function () {
+    $model = MobilePass::factory()->make([
+        'builder_name' => EventTicketPassBuilder::name(),
+        'content' => [
+            'organizationName' => 'Fab Four Promotions',
+            'serialNumber' => 'BTL-SHEA-0042',
+            'description' => 'The Beatles at Shea Stadium',
+            'relevantDates' => [
+                ['date' => '1965-08-15T20:00:00-04:00'],
+                ['startDate' => '1965-08-15T18:00:00-04:00', 'endDate' => '1965-08-15T23:00:00-04:00'],
+            ],
+        ],
+    ]);
+
+    $data = EventTicketPassBuilder::hydrate($model)->data();
+
+    expect($data['relevantDates'])->toHaveCount(2);
+    expect($data['relevantDates'][0]['date'])->toStartWith('1965-08-15T20:00:00');
+    expect($data['relevantDates'][1]['startDate'])->toStartWith('1965-08-15T18:00:00');
+    expect($data['relevantDates'][1]['endDate'])->toStartWith('1965-08-15T23:00:00');
+});
+
 it('serialises locations and max distance onto the pass', function () {
     $data = EventTicketPassBuilder::make()
         ->setOrganizationName('Fab Four Promotions')

--- a/tests/Entities/RelevantDateTest.php
+++ b/tests/Entities/RelevantDateTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Carbon;
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\RelevantDate;
+
+it('serializes a single relevant date', function () {
+    $relevantDate = RelevantDate::make(date: Carbon::parse('1965-08-15T20:00:00-04:00'));
+
+    expect($relevantDate->toArray())->toBe([
+        'date' => '1965-08-15T20:00:00-04:00',
+    ]);
+});
+
+it('serializes a relevant date interval', function () {
+    $relevantDate = RelevantDate::make(
+        startDate: Carbon::parse('1965-08-15T18:00:00-04:00'),
+        endDate: Carbon::parse('1965-08-15T23:00:00-04:00'),
+    );
+
+    expect($relevantDate->toArray())->toBe([
+        'startDate' => '1965-08-15T18:00:00-04:00',
+        'endDate' => '1965-08-15T23:00:00-04:00',
+    ]);
+});
+
+it('hydrates from an array', function () {
+    $relevantDate = RelevantDate::fromArray([
+        'startDate' => '1965-08-15T18:00:00-04:00',
+        'endDate' => '1965-08-15T23:00:00-04:00',
+    ]);
+
+    expect($relevantDate->date)->toBeNull();
+    expect($relevantDate->startDate->toIso8601String())->toBe('1965-08-15T18:00:00-04:00');
+    expect($relevantDate->endDate->toIso8601String())->toBe('1965-08-15T23:00:00-04:00');
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                         
  - Apple's legacy `relevantDate` only supports a single moment. iOS 18+ introduces `Pass.RelevantDates`, an array letting a pass declare multiple relevance windows — either a  single `date` or an explicit `startDate`/`endDate` interval per entry.                                                                                                             
  - Adds `addRelevantDate()` and `addRelevantDateInterval()` alongside the existing `setRelevantDate()`, so passes can opt into the richer relevance model without losing the legacy  field.                                                                                                                                                                             
                                                                                                                                                                                     
  ## Changes                                                                                                                                                                         
  - `src/Builders/Apple/Entities/RelevantDate.php` (new): models `Pass.RelevantDates` (`date`, `startDate`, `endDate`).                                                              
  - `src/Builders/Apple/ApplePassBuilder.php`: new `addRelevantDate(Carbon $date)` and `addRelevantDateInterval(Carbon $startDate, Carbon $endDate)` methods, wired through          
  `compileData()`/`uncompileContent()`. Kept as two separate methods (rather than one with optional params) so an invalid combination — e.g. `startDate` without `endDate` — can't be constructed at all.           
                                                                                                                                                       
  - `src/Builders/Apple/Validators/ApplePassValidator.php`: allow-list the new `relevantDates` key.                                                                                  
  - `tests/Builders/Apple/RelevanceTest.php`: serialize + round-trip coverage.                                                                                                       
  - `tests/Entities/RelevantDateTest.php` (new): entity-level unit tests.                                                                                                            
  - `docs/apple-wallet/pass-relevance.md`: new "Relevant date intervals" section. 

## Test plan

- [x] Full test suite run locally (all passing)