### PR TITLE
feat: apple pass personalization

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,20 @@
 # Upgrading
 
+## Apple Wallet Pass Personalization
+
+This release adds Apple Wallet pass personalization support via a new `apple_mobile_pass_personalizations` table.
+
+**New installs** — publish and run the package migrations normally.
+
+**Existing installs** — publish and run the new migration:
+
+```bash
+php artisan vendor:publish --tag="mobile-pass-migrations"
+php artisan migrate
+```
+
+---
+
 ## Google Wallet i18n — LocalizedString for Loyalty and Offer pass classes
 
 `LoyaltyPassClass` and `OfferPassClass` now support per-locale translations.

--- a/config/mobile-pass.php
+++ b/config/mobile-pass.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\LaravelMobilePass\Actions\Apple\NotifyAppleOfPassUpdateAction;
+use Spatie\LaravelMobilePass\Actions\Apple\PersonalizeAction;
 use Spatie\LaravelMobilePass\Actions\Apple\RegisterDeviceAction;
 use Spatie\LaravelMobilePass\Actions\Apple\UnregisterDeviceAction;
 use Spatie\LaravelMobilePass\Actions\Google\HandleGoogleCallbackAction;
@@ -68,6 +69,7 @@ return [
         'handle_google_callback' => HandleGoogleCallbackAction::class,
         'notify_apple_of_pass_update' => NotifyAppleOfPassUpdateAction::class,
         'notify_google_of_pass_update' => NotifyGoogleOfPassUpdateAction::class,
+        'personalize' => PersonalizeAction::class,
         'register_device' => RegisterDeviceAction::class,
         'unregister_device' => UnregisterDeviceAction::class,
     ],

--- a/config/mobile-pass.php
+++ b/config/mobile-pass.php
@@ -6,6 +6,7 @@ use Spatie\LaravelMobilePass\Actions\Apple\UnregisterDeviceAction;
 use Spatie\LaravelMobilePass\Actions\Google\HandleGoogleCallbackAction;
 use Spatie\LaravelMobilePass\Actions\Google\NotifyGoogleOfPassUpdateAction;
 use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassDevice;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
 use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassRegistration;
 use Spatie\LaravelMobilePass\Models\Google\GoogleMobilePassEvent;
 use Spatie\LaravelMobilePass\Models\MobilePass;
@@ -79,6 +80,7 @@ return [
         'mobile_pass' => MobilePass::class,
         'apple_mobile_pass_registration' => AppleMobilePassRegistration::class,
         'apple_mobile_pass_device' => AppleMobilePassDevice::class,
+        'apple_mobile_pass_personalization' => AppleMobilePassPersonalization::class,
         'google_mobile_pass_event' => GoogleMobilePassEvent::class,
     ],
 

--- a/database/factories/AppleMobilePassPersonalizationFactory.php
+++ b/database/factories/AppleMobilePassPersonalizationFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+class AppleMobilePassPersonalizationFactory extends Factory
+{
+    protected $model = AppleMobilePassPersonalization::class;
+
+    public function definition(): array
+    {
+        return [
+            'mobile_pass_id' => MobilePass::factory(),
+            'description' => 'Sign up to earn points.',
+            'required_fields' => ['PKPassPersonalizationFieldName', 'PKPassPersonalizationFieldEmailAddress'],
+            'terms_and_conditions' => null,
+            'personalization_token' => null,
+            'submitted_info' => null,
+            'personalized_at' => null,
+        ];
+    }
+}

--- a/database/migrations/create_apple_mobile_pass_personalizations_table.php.stub
+++ b/database/migrations/create_apple_mobile_pass_personalizations_table.php.stub
@@ -12,6 +12,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
 
             $table->foreignUuid('mobile_pass_id')
+                ->unique()
                 ->constrained('mobile_passes')
                 ->cascadeOnDelete();
 

--- a/database/migrations/create_apple_mobile_pass_personalizations_table.php.stub
+++ b/database/migrations/create_apple_mobile_pass_personalizations_table.php.stub
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('apple_mobile_pass_personalizations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('mobile_pass_id')
+                ->constrained('mobile_passes')
+                ->cascadeOnDelete();
+
+            $table->string('description');
+            $table->json('required_fields');
+            $table->text('terms_and_conditions')->nullable();
+
+            $table->string('personalization_token')->nullable();
+            $table->json('submitted_info')->nullable();
+            $table->timestamp('personalized_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('apple_mobile_pass_personalizations');
+    }
+};

--- a/docs/advanced-usage/customizing-actions.md
+++ b/docs/advanced-usage/customizing-actions.md
@@ -42,7 +42,7 @@ return [
 
 ## Available actions
 
-The five actions below are registered under the `actions` key in `config/mobile-pass.php`. Each one can be swapped out independently.
+The six actions below are registered under the `actions` key in `config/mobile-pass.php`. Each one can be swapped out independently.
 
 ### register_device
 
@@ -67,6 +67,12 @@ Runs after a `MobilePass` row is updated for an Apple pass. It signs and sends a
 Default: `Spatie\LaravelMobilePass\Actions\Google\NotifyGoogleOfPassUpdateAction`
 
 Runs after a `MobilePass` row is updated for a Google pass. It sends a PATCH request to Google's Wallet REST API with the new object payload, and Google fans the change out to devices. Override to add extra telemetry, to patch additional fields, or to short-circuit when you know Google already has the latest state.
+
+### personalize
+
+Default: `Spatie\LaravelMobilePass\Actions\Apple\PersonalizeAction`
+
+Runs when Wallet calls the personalize endpoint after the user submits their enrollment information. It signs the personalization token, records the submission on the `AppleMobilePassPersonalization` row, and fires `PassPersonalized`. Override to change how submissions are persisted or to add validation before the signature is produced.
 
 ### handle_google_callback
 

--- a/docs/advanced-usage/events.md
+++ b/docs/advanced-usage/events.md
@@ -80,6 +80,31 @@ class ForwardAppleWalletLogs
 
 The payload is a plain `array<string>` of log lines. There's no Google equivalent; Google Wallet doesn't post back error logs.
 
+## PassPersonalized
+
+The `Spatie\LaravelMobilePass\Events\PassPersonalized` event fires after Wallet successfully submits a user's enrollment information to the `/personalize` endpoint on an Apple pass configured for [personalization](../apple-wallet/pass-personalization).
+
+The event carries the `MobilePass` model (`$event->mobilePass`) and the submitted data (`$event->submittedInfo`, an `array`). This is the intended hook for creating the user's account, syncing a CRM, or sending a welcome email — the package deliberately doesn't do any of that itself.
+
+```php
+namespace App\Listeners;
+
+use Spatie\LaravelMobilePass\Events\PassPersonalized;
+
+class CreateUserAccount
+{
+    public function handle(PassPersonalized $event): void
+    {
+        $mobilePass = $event->mobilePass;
+        $submittedInfo = $event->submittedInfo;
+
+        // Create or update the user, then link the pass to it
+    }
+}
+```
+
+Wallet may retry the `/personalize` POST for the same pass, so write this listener idempotently rather than assuming a single delivery.
+
 ## Registering listeners
 
 Laravel 11+ auto-discovers listeners in `app/Listeners` by convention. If you've opted into explicit registration, add entries to your `EventServiceProvider`:

--- a/docs/apple-wallet/pass-personalization.md
+++ b/docs/apple-wallet/pass-personalization.md
@@ -1,0 +1,112 @@
+---
+title: Pass personalization
+weight: 7
+---
+
+Apple Wallet lets you collect customer information right from the pass itself. A loyalty card can ask for the member's email address, a rewards pass can collect postal code or phone number, and a membership card can gather multiple fields. This is called pass personalization, and it's a streamlined way to build your customer database without redirecting to your website.
+
+Personalization is Apple-only and NFC-only. The package enforces the NFC requirement: if you configure personalization without NFC, building the pass throws an `InvalidConfig` exception.
+
+## Setting up personalization
+
+Use `setPersonalization()` on your builder, passing a `Personalization` instance created with `Personalization::make()`. Tell it what description to show in Wallet, which fields to ask for, and optionally a terms-and-conditions message:
+
+```php
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Personalization;
+use Spatie\LaravelMobilePass\Enums\PersonalizationField;
+
+$builder->setPersonalization(
+    Personalization::make(
+        description: 'Complete your profile to unlock rewards',
+        requiredPersonalizationFields: [
+            PersonalizationField::Name,
+            PersonalizationField::EmailAddress,
+        ],
+        termsAndConditions: 'We'll use your email to send loyalty updates. You can unsubscribe anytime.',
+    )
+);
+```
+
+The four available fields are:
+
+- `PersonalizationField::Name` — the member's name
+- `PersonalizationField::PostalCode` — a postal code (e.g. ZIP for US, postcode for UK)
+- `PersonalizationField::EmailAddress` — an email address
+- `PersonalizationField::PhoneNumber` — a phone number
+
+Personalization always requires NFC. Set it up with `setNfc()` before calling `setPersonalization()`:
+
+```php
+$builder
+    ->setNfc(
+        message: 'Tap to earn points',
+        encryptionPublicKey: 'your-public-key',
+    )
+    ->setPersonalization(
+        Personalization::make(
+            description: 'Complete your profile to unlock rewards',
+            requiredPersonalizationFields: [PersonalizationField::EmailAddress],
+        )
+    );
+```
+
+## Personalization logo
+
+Personalization shows a logo in Wallet when the user completes their profile. Provide it with `setPersonalizationLogo()`, just like other images in the pass:
+
+```php
+$builder->setPersonalizationLogo(
+    x1Path: 'resources/pass-images/personalization-logo@1x.png',
+    x2Path: 'resources/pass-images/personalization-logo@2x.png',
+    x3Path: 'resources/pass-images/personalization-logo@3x.png',
+);
+```
+
+Only the `@1x` image is required; `@2x` and `@3x` are optional.
+
+## Handling the personalization endpoint
+
+The `/personalize` web-service endpoint that Wallet calls after the user submits their information is wired up automatically by the package. You don't need to define a route or controller — it's handled behind the scenes.
+
+## Listening for personalization
+
+Once the user submits their information, the package fires the `PassPersonalized` event. This is where you should create the user's account, sync a CRM, send a welcome email, or do anything else your app needs:
+
+```php
+namespace App\Listeners;
+
+use Spatie\LaravelMobilePass\Events\PassPersonalized;
+
+class CreateUserAccount
+{
+    public function handle(PassPersonalized $event): void
+    {
+        $mobilePass = $event->mobilePass;
+        $submittedInfo = $event->submittedInfo; // array of user-entered data
+
+        // Create or update the user
+        $user = User::updateOrCreate(
+            ['email' => $submittedInfo['emailAddress'] ?? null],
+            [
+                'name' => $submittedInfo['name'] ?? null,
+                'email' => $submittedInfo['emailAddress'] ?? null,
+                'phone' => $submittedInfo['phoneNumber'] ?? null,
+                'postal_code' => $submittedInfo['postalCode'] ?? null,
+            ]
+        );
+
+        // Link the mobile pass to the user
+        $mobilePass->update(['user_id' => $user->id]);
+
+        // Send a welcome email, trigger onboarding, etc.
+    }
+}
+```
+
+The `$submittedInfo` array contains the fields the user filled in, keyed by their lowercase name: `name`, `emailAddress`, `phoneNumber`, `postalCode`.
+
+Register your listener in `EventServiceProvider` or let Laravel 11+ auto-discover it from `app/Listeners`. See [Events](advanced-usage/events) for listener setup details.
+
+## Why you handle account creation
+
+Apple's spec explicitly places account creation on your server, not the package. The package delivers the submitted information and fires the event; your listener decides whether to create an account, sync an external system, update an existing user, or skip the whole thing. This keeps the package lightweight and lets your app apply your business logic.

--- a/docs/apple-wallet/pass-personalization.md
+++ b/docs/apple-wallet/pass-personalization.md
@@ -22,7 +22,7 @@ $builder->setPersonalization(
             PersonalizationField::Name,
             PersonalizationField::EmailAddress,
         ],
-        termsAndConditions: 'We'll use your email to send loyalty updates. You can unsubscribe anytime.',
+        termsAndConditions: "We'll use your email to send loyalty updates. You can unsubscribe anytime.",
     )
 );
 ```
@@ -52,7 +52,7 @@ $builder
 
 ## Personalization logo
 
-Personalization shows a logo in Wallet when the user completes their profile. Provide it with `setPersonalizationLogo()`, just like other images in the pass:
+Personalization shows a logo in Wallet during the enrollment flow, displayed at the top of the signup form. Provide it with `setPersonalizationLogo()`, just like other images in the pass:
 
 ```php
 $builder->setPersonalizationLogo(
@@ -85,10 +85,11 @@ class CreateUserAccount
         $submittedInfo = $event->submittedInfo; // array of user-entered data
 
         // Create or update the user
+        // Note: field keys depend on what Wallet sends; this example assumes fullName and emailAddress
         $user = User::updateOrCreate(
             ['email' => $submittedInfo['emailAddress'] ?? null],
             [
-                'name' => $submittedInfo['name'] ?? null,
+                'name' => $submittedInfo['fullName'] ?? null,
                 'email' => $submittedInfo['emailAddress'] ?? null,
                 'phone' => $submittedInfo['phoneNumber'] ?? null,
                 'postal_code' => $submittedInfo['postalCode'] ?? null,
@@ -103,7 +104,7 @@ class CreateUserAccount
 }
 ```
 
-The `$submittedInfo` array contains the fields the user filled in, keyed by their lowercase name: `name`, `emailAddress`, `phoneNumber`, `postalCode`.
+The `$submittedInfo` array is a verbatim passthrough of the `requiredPersonalizationInfo` payload Wallet sends — its structure and key names are controlled by Apple, not this package. The example above uses `fullName` (for `PersonalizationField::Name`) and `emailAddress` (for `PersonalizationField::EmailAddress`); check your pass builder's `requiredPersonalizationFields` to understand which keys will be present in your listener.
 
 Register your listener in `EventServiceProvider` or let Laravel 11+ auto-discover it from `app/Listeners`. See [Events](advanced-usage/events) for listener setup details.
 

--- a/docs/apple-wallet/pass-personalization.md
+++ b/docs/apple-wallet/pass-personalization.md
@@ -34,7 +34,7 @@ The four available fields are:
 - `PersonalizationField::EmailAddress` — an email address
 - `PersonalizationField::PhoneNumber` — a phone number
 
-Personalization always requires NFC. Set it up with `setNfc()` before calling `setPersonalization()`:
+Personalization always requires NFC. Set it up with `setNfc()`, in either order relative to `setPersonalization()` — the package checks for NFC when the pass is built, not when either method is called:
 
 ```php
 $builder
@@ -52,7 +52,7 @@ $builder
 
 ## Personalization logo
 
-Personalization shows a logo in Wallet during the enrollment flow, displayed at the top of the signup form. Provide it with `setPersonalizationLogo()`, just like other images in the pass:
+Personalization shows a logo in Wallet during the enrollment flow. Provide it with `setPersonalizationLogo()`, just like other images in the pass:
 
 ```php
 $builder->setPersonalizationLogo(
@@ -97,7 +97,7 @@ class CreateUserAccount
         );
 
         // Link the mobile pass to the user
-        $mobilePass->update(['user_id' => $user->id]);
+        $mobilePass->model()->associate($user)->save();
 
         // Send a welcome email, trigger onboarding, etc.
     }

--- a/routes/mobile-pass.php
+++ b/routes/mobile-pass.php
@@ -5,6 +5,7 @@ use Spatie\LaravelMobilePass\Http\Controllers\Apple\CheckForUpdatesController;
 use Spatie\LaravelMobilePass\Http\Controllers\Apple\DownloadApplePassController;
 use Spatie\LaravelMobilePass\Http\Controllers\Apple\GetAssociatedSerialsForDeviceController;
 use Spatie\LaravelMobilePass\Http\Controllers\Apple\MobilePassLogController;
+use Spatie\LaravelMobilePass\Http\Controllers\Apple\PersonalizeController;
 use Spatie\LaravelMobilePass\Http\Controllers\Apple\RegisterDeviceController;
 use Spatie\LaravelMobilePass\Http\Controllers\Apple\UnregisterDeviceController;
 use Spatie\LaravelMobilePass\Http\Controllers\Google\HandleCallbackController;
@@ -20,6 +21,9 @@ Route::macro('mobilePass', function (string $prefix = '') {
 
             Route::get('passes/{passTypeId}/{passSerial}', CheckForUpdatesController::class)
                 ->name('mobile-pass.check-for-updates');
+
+            Route::post('passes/{passTypeId}/{passSerial}/personalize', PersonalizeController::class)
+                ->name('mobile-pass.apple.personalize');
 
             Route::delete('devices/{deviceId}/registrations/{passTypeId}/{passSerial}', UnregisterDeviceController::class)
                 ->name('mobile-pass.unregister-device');

--- a/src/Actions/Apple/PersonalizeAction.php
+++ b/src/Actions/Apple/PersonalizeAction.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Actions\Apple;
+
+use Spatie\LaravelMobilePass\Events\PassPersonalized;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+use Spatie\LaravelMobilePass\Support\Apple\PersonalizationTokenSigner;
+
+class PersonalizeAction
+{
+    /** @param  array<string, mixed>  $submittedInfo */
+    public function execute(MobilePass $pass, string $personalizationToken, array $submittedInfo): string
+    {
+        $pass->personalization()->updateOrCreate([], [
+            'personalization_token' => $personalizationToken,
+            'submitted_info' => $submittedInfo,
+            'personalized_at' => now(),
+        ]);
+
+        $pass->touch();
+
+        event(new PassPersonalized($pass, $submittedInfo));
+
+        return (new PersonalizationTokenSigner)->sign($personalizationToken);
+    }
+}

--- a/src/Actions/Apple/PersonalizeAction.php
+++ b/src/Actions/Apple/PersonalizeAction.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelMobilePass\Actions\Apple;
 use Spatie\LaravelMobilePass\Events\PassPersonalized;
 use Spatie\LaravelMobilePass\Models\MobilePass;
 use Spatie\LaravelMobilePass\Support\Apple\PersonalizationTokenSigner;
+use Throwable;
 
 class PersonalizeAction
 {
@@ -21,8 +22,21 @@ class PersonalizeAction
             'personalized_at' => now(),
         ]);
 
-        $pass->touch();
+        try {
+            // touch() synchronously dispatches a push notification to every registered
+            // device (via MobilePass::boot()'s `updated` listener). The signature has
+            // already been produced and the submission already recorded above, so a push
+            // failure here is a best-effort side effect, not part of the personalize
+            // contract: it must not turn an otherwise-successful response into a 500,
+            // which would leave the pass stuck in "personalized" state without Wallet
+            // ever having received its valid signature.
+            $pass->touch();
+        } catch (Throwable $exception) {
+            report($exception);
+        }
 
+        // Wallet may retry the /personalize POST, so listeners on PassPersonalized
+        // should be written idempotently rather than assuming a single delivery per pass.
         event(new PassPersonalized($pass, $submittedInfo));
 
         return $signature;

--- a/src/Actions/Apple/PersonalizeAction.php
+++ b/src/Actions/Apple/PersonalizeAction.php
@@ -11,7 +11,11 @@ class PersonalizeAction
     /** @param  array<string, mixed>  $submittedInfo */
     public function execute(MobilePass $pass, string $personalizationToken, array $submittedInfo): string
     {
-        $pass->personalization()->updateOrCreate([], [
+        $personalization = $pass->personalization()->firstOrFail();
+
+        $signature = (new PersonalizationTokenSigner)->sign($personalizationToken);
+
+        $personalization->update([
             'personalization_token' => $personalizationToken,
             'submitted_info' => $submittedInfo,
             'personalized_at' => now(),
@@ -21,6 +25,6 @@ class PersonalizeAction
 
         event(new PassPersonalized($pass, $submittedInfo));
 
-        return (new PersonalizationTokenSigner)->sign($personalizationToken);
+        return $signature;
     }
 }

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -710,25 +710,29 @@ abstract class ApplePassBuilder
     public function save(): MobilePass
     {
         if ($this->model) {
-            $this->serialNumber = $this->model->pass_serial;
+            $model = $this->model;
 
-            $this->model->update([
+            $this->serialNumber = $model->pass_serial;
+
+            $model->update([
                 'content' => $this->data(),
                 'images' => $this->images,
                 'locales' => empty($this->locales) ? null : $this->locales,
                 'download_name' => $this->downloadName,
             ]);
 
+            $this->model = $model;
+
             $this->savePersonalizationConfig();
 
-            return $this->model;
+            return $model;
         }
 
         $content = $this->data();
 
         $mobilePassClass = Config::mobilePassModel();
 
-        $this->model = $mobilePassClass::query()->create([
+        $model = $mobilePassClass::query()->create([
             'pass_serial' => $this->serialNumber,
             'type' => $this->type->value,
             'platform' => static::platform(),
@@ -739,9 +743,11 @@ abstract class ApplePassBuilder
             'download_name' => $this->downloadName,
         ]);
 
+        $this->model = $model;
+
         $this->savePersonalizationConfig();
 
-        return $this->model;
+        return $model;
     }
 
     protected function savePersonalizationConfig(): void

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -15,6 +15,7 @@ use Spatie\LaravelMobilePass\Builders\Apple\Entities\FieldContent;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Image;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Location;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\NfcPayload;
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Personalization;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\Price;
 use Spatie\LaravelMobilePass\Builders\Apple\Entities\WifiNetwork;
 use Spatie\LaravelMobilePass\Builders\Apple\Validators\ApplePassValidator;
@@ -22,6 +23,7 @@ use Spatie\LaravelMobilePass\Enums\BarcodeType;
 use Spatie\LaravelMobilePass\Enums\DateType;
 use Spatie\LaravelMobilePass\Enums\FieldType;
 use Spatie\LaravelMobilePass\Enums\PassType;
+use Spatie\LaravelMobilePass\Enums\PersonalizationField;
 use Spatie\LaravelMobilePass\Enums\Platform;
 use Spatie\LaravelMobilePass\Enums\TimeStyleType;
 use Spatie\LaravelMobilePass\Exceptions\InvalidCertificate;
@@ -87,6 +89,8 @@ abstract class ApplePassBuilder
     protected array $beacons = [];
 
     protected ?NfcPayload $nfc = null;
+
+    protected ?Personalization $personalization = null;
 
     abstract protected static function validator(): ApplePassValidator;
 
@@ -590,9 +594,43 @@ abstract class ApplePassBuilder
         return $this;
     }
 
+    public function setPersonalization(Personalization $personalization): static
+    {
+        $this->personalization = $personalization;
+
+        return $this;
+    }
+
+    public function setPersonalizationLogo(string $x1Path, ?string $x2Path = null, ?string $x3Path = null): static
+    {
+        $this->images['personalizationLogo'] = new Image($x1Path, $x2Path, $x3Path);
+
+        return $this;
+    }
+
+    protected function isPersonalized(): bool
+    {
+        return $this->model?->personalization?->personalized_at !== null;
+    }
+
+    protected function addPersonalizationToFile(PKPass $pkPass): void
+    {
+        if ($this->personalization === null || $this->isPersonalized()) {
+            return;
+        }
+
+        $pkPass->addFileContent(json_encode($this->personalization->toArray()), 'personalization.json');
+    }
+
     protected function addImagesToFile(PKPass $pkPass): PKPass
     {
-        foreach ($this->images as $filename => $image) {
+        $images = $this->images;
+
+        if ($this->isPersonalized()) {
+            unset($images['personalizationLogo']);
+        }
+
+        foreach ($images as $filename => $image) {
             if (! $image instanceof Image) {
                 $image = Image::fromArray($image);
             }
@@ -678,6 +716,8 @@ abstract class ApplePassBuilder
                 'download_name' => $this->downloadName,
             ]);
 
+            $this->savePersonalizationConfig();
+
             return $this->model;
         }
 
@@ -685,7 +725,7 @@ abstract class ApplePassBuilder
 
         $mobilePassClass = Config::mobilePassModel();
 
-        return $mobilePassClass::query()->create([
+        $this->model = $mobilePassClass::query()->create([
             'pass_serial' => $this->serialNumber,
             'type' => $this->type->value,
             'platform' => static::platform(),
@@ -695,10 +735,34 @@ abstract class ApplePassBuilder
             'locales' => empty($this->locales) ? null : $this->locales,
             'download_name' => $this->downloadName,
         ]);
+
+        $this->savePersonalizationConfig();
+
+        return $this->model;
+    }
+
+    protected function savePersonalizationConfig(): void
+    {
+        if ($this->personalization === null) {
+            return;
+        }
+
+        $this->model->personalization()->updateOrCreate([], [
+            'description' => $this->personalization->description,
+            'required_fields' => array_map(
+                fn ($field) => $field->value,
+                $this->personalization->requiredPersonalizationFields,
+            ),
+            'terms_and_conditions' => $this->personalization->termsAndConditions,
+        ]);
     }
 
     public function data(): array
     {
+        if ($this->personalization !== null && $this->nfc === null) {
+            throw InvalidConfig::personalizationRequiresNfc();
+        }
+
         $configuredOrganizationName = self::appleConfig('organization_name');
 
         if (empty($this->organizationName)) {
@@ -731,6 +795,7 @@ abstract class ApplePassBuilder
 
             $this->addImagesToFile($pkPass);
             $this->addLocaleDataToPass($pkPass);
+            $this->addPersonalizationToFile($pkPass);
 
             return $pkPass->create(output: false);
         } catch (PKPassException $exception) {
@@ -894,6 +959,17 @@ abstract class ApplePassBuilder
         $this->nfc = empty($this->data['nfc'])
             ? null
             : NfcPayload::fromArray($this->data['nfc']);
+
+        $this->personalization = $this->model?->personalization
+            ? Personalization::make(
+                description: $this->model->personalization->description,
+                requiredPersonalizationFields: array_map(
+                    fn (string $field) => PersonalizationField::from($field),
+                    $this->model->personalization->required_fields,
+                ),
+                termsAndConditions: $this->model->personalization->terms_and_conditions,
+            )
+            : null;
 
         $this->uncompileSemantics();
 

--- a/src/Builders/Apple/ApplePassBuilder.php
+++ b/src/Builders/Apple/ApplePassBuilder.php
@@ -28,6 +28,7 @@ use Spatie\LaravelMobilePass\Enums\Platform;
 use Spatie\LaravelMobilePass\Enums\TimeStyleType;
 use Spatie\LaravelMobilePass\Exceptions\InvalidCertificate;
 use Spatie\LaravelMobilePass\Exceptions\InvalidConfig;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
 use Spatie\LaravelMobilePass\Models\MobilePass;
 use Spatie\LaravelMobilePass\Support\Config;
 use Spatie\LaravelMobilePass\Support\WifiUri;
@@ -91,6 +92,8 @@ abstract class ApplePassBuilder
     protected ?NfcPayload $nfc = null;
 
     protected ?Personalization $personalization = null;
+
+    protected ?AppleMobilePassPersonalization $personalizationRecord = null;
 
     abstract protected static function validator(): ApplePassValidator;
 
@@ -610,7 +613,7 @@ abstract class ApplePassBuilder
 
     protected function isPersonalized(): bool
     {
-        return $this->model?->personalization?->personalized_at !== null;
+        return $this->personalizationRecord?->personalized_at !== null;
     }
 
     protected function addPersonalizationToFile(PKPass $pkPass): void
@@ -960,14 +963,16 @@ abstract class ApplePassBuilder
             ? null
             : NfcPayload::fromArray($this->data['nfc']);
 
-        $this->personalization = $this->model?->personalization
+        $this->personalizationRecord = $this->model?->personalization()->first();
+
+        $this->personalization = $this->personalizationRecord
             ? Personalization::make(
-                description: $this->model->personalization->description,
+                description: $this->personalizationRecord->description,
                 requiredPersonalizationFields: array_map(
                     fn (string $field) => PersonalizationField::from($field),
-                    $this->model->personalization->required_fields,
+                    $this->personalizationRecord->required_fields,
                 ),
-                termsAndConditions: $this->model->personalization->terms_and_conditions,
+                termsAndConditions: $this->personalizationRecord->terms_and_conditions,
             )
             : null;
 

--- a/src/Builders/Apple/Entities/Personalization.php
+++ b/src/Builders/Apple/Entities/Personalization.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Builders\Apple\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Spatie\LaravelMobilePass\Enums\PersonalizationField;
+
+class Personalization implements Arrayable
+{
+    /** @param  array<int, PersonalizationField>  $requiredPersonalizationFields */
+    public function __construct(
+        public string $description,
+        public array $requiredPersonalizationFields,
+        public ?string $termsAndConditions = null,
+    ) {}
+
+    /** @param  array<int, PersonalizationField>  $requiredPersonalizationFields */
+    public static function make(
+        string $description,
+        array $requiredPersonalizationFields,
+        ?string $termsAndConditions = null,
+    ): self {
+        return new self($description, $requiredPersonalizationFields, $termsAndConditions);
+    }
+
+    /** @param  array<string, mixed>  $values */
+    public static function fromArray(array $values): self
+    {
+        return new self(
+            description: $values['description'],
+            requiredPersonalizationFields: array_map(
+                fn (string $field) => PersonalizationField::from($field),
+                $values['requiredPersonalizationFields'] ?? [],
+            ),
+            termsAndConditions: $values['termsAndConditions'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'requiredPersonalizationFields' => array_map(
+                fn (PersonalizationField $field) => $field->value,
+                $this->requiredPersonalizationFields,
+            ),
+            'description' => $this->description,
+            'termsAndConditions' => $this->termsAndConditions,
+        ], fn ($value) => $value !== null);
+    }
+}

--- a/src/Enums/PersonalizationField.php
+++ b/src/Enums/PersonalizationField.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Enums;
+
+enum PersonalizationField: string
+{
+    case Name = 'PKPassPersonalizationFieldName';
+    case PostalCode = 'PKPassPersonalizationFieldPostalCode';
+    case EmailAddress = 'PKPassPersonalizationFieldEmailAddress';
+    case PhoneNumber = 'PKPassPersonalizationFieldPhoneNumber';
+}

--- a/src/Events/PassPersonalized.php
+++ b/src/Events/PassPersonalized.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+class PassPersonalized
+{
+    use Dispatchable;
+
+    /** @param  array<string, mixed>  $submittedInfo */
+    public function __construct(
+        public MobilePass $mobilePass,
+        public array $submittedInfo,
+    ) {}
+}

--- a/src/Exceptions/InvalidCertificate.php
+++ b/src/Exceptions/InvalidCertificate.php
@@ -18,4 +18,13 @@ class InvalidCertificate extends Exception implements MobilePassException
             $previous,
         );
     }
+
+    public static function fromPkcs12ReadFailure(): self
+    {
+        return new self(
+            'The Apple Wallet pass-signing certificate could not be loaded. '
+            .'Verify MOBILE_PASS_APPLE_CERTIFICATE_PATH or MOBILE_PASS_APPLE_CERTIFICATE, '
+            .'and confirm MOBILE_PASS_APPLE_CERTIFICATE_PASSWORD is correct.',
+        );
+    }
 }

--- a/src/Exceptions/InvalidCertificate.php
+++ b/src/Exceptions/InvalidCertificate.php
@@ -27,4 +27,13 @@ class InvalidCertificate extends Exception implements MobilePassException
             .'and confirm MOBILE_PASS_APPLE_CERTIFICATE_PASSWORD is correct.',
         );
     }
+
+    public static function fromPkcs7SignFailure(): self
+    {
+        return new self(
+            'The Apple Wallet personalization token could not be signed. '
+            .'Verify MOBILE_PASS_APPLE_CERTIFICATE_PATH or MOBILE_PASS_APPLE_CERTIFICATE, '
+            .'and confirm MOBILE_PASS_APPLE_CERTIFICATE_PASSWORD is correct.',
+        );
+    }
 }

--- a/src/Exceptions/InvalidConfig.php
+++ b/src/Exceptions/InvalidConfig.php
@@ -63,4 +63,12 @@ class InvalidConfig extends Exception implements MobilePassException
             .'supports a barcode format this version does not yet know about.'
         );
     }
+
+    public static function personalizationRequiresNfc(): self
+    {
+        return new self(
+            'Personalization requires NFC to be configured first. Apple restricts pass personalization '
+            .'(rewards enrollment) to NFC-enabled passes. Call setNfc() before calling data()/generate()/save().'
+        );
+    }
 }

--- a/src/Http/Controllers/Apple/PersonalizeController.php
+++ b/src/Http/Controllers/Apple/PersonalizeController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Http\Controllers\Apple;
+
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Spatie\LaravelMobilePass\Actions\Apple\PersonalizeAction;
+use Spatie\LaravelMobilePass\Http\Requests\Apple\PersonalizeRequest;
+use Spatie\LaravelMobilePass\Support\Config;
+
+/**
+ * Implementing the Web Service (personalize endpoint)
+ * Apple Wallet Developer Guide: Rewards Enrollment
+ */
+class PersonalizeController extends Controller
+{
+    public function __invoke(PersonalizeRequest $request): Response
+    {
+        /** @var class-string<PersonalizeAction> $actionClass */
+        $actionClass = Config::getActionClass('personalize', PersonalizeAction::class);
+
+        $signature = (new $actionClass)->execute(
+            $request->mobilePass(),
+            $request->input('personalizationToken'),
+            $request->input('requiredPersonalizationInfo'),
+        );
+
+        return response($signature, 200, ['Content-Type' => 'application/octet-stream']);
+    }
+}

--- a/src/Http/Requests/Apple/PersonalizeRequest.php
+++ b/src/Http/Requests/Apple/PersonalizeRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Http\Requests\Apple;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+use Spatie\LaravelMobilePass\Support\Config;
+
+class PersonalizeRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'personalizationToken' => ['required', 'string'],
+            'requiredPersonalizationInfo' => ['required', 'array'],
+        ];
+    }
+
+    public function mobilePass(): MobilePass
+    {
+        $mobilePassClass = Config::mobilePassModel();
+
+        return $mobilePassClass::query()
+            ->where('pass_serial', $this->route('passSerial'))
+            ->firstOrFail();
+    }
+}

--- a/src/MobilePassServiceProvider.php
+++ b/src/MobilePassServiceProvider.php
@@ -16,7 +16,8 @@ class MobilePassServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasRoutes('mobile-pass')
             ->hasMigration('create_mobile_pass_tables')
-            ->hasMigration('add_locales_to_mobile_passes_table');
+            ->hasMigration('add_locales_to_mobile_passes_table')
+            ->hasMigration('create_apple_mobile_pass_personalizations_table');
     }
 
     public function registeringPackage(): void

--- a/src/Models/Apple/AppleMobilePassPersonalization.php
+++ b/src/Models/Apple/AppleMobilePassPersonalization.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Models\Apple;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+use Spatie\LaravelMobilePass\Support\Config;
+
+/**
+ * @property string $mobile_pass_id
+ * @property string $description
+ * @property array $required_fields
+ * @property ?string $terms_and_conditions
+ * @property ?string $personalization_token
+ * @property ?array $submitted_info
+ * @property ?\Illuminate\Support\Carbon $personalized_at
+ * @property MobilePass $pass
+ */
+class AppleMobilePassPersonalization extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    public $guarded = [];
+
+    public function pass(): BelongsTo
+    {
+        return $this->belongsTo(Config::mobilePassModel(), 'mobile_pass_id');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'required_fields' => 'json',
+            'submitted_info' => 'json',
+            'personalized_at' => 'datetime',
+        ];
+    }
+}

--- a/src/Models/MobilePass.php
+++ b/src/Models/MobilePass.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Mail\Attachment;
 use Illuminate\Support\Facades\URL;
@@ -22,6 +23,7 @@ use Spatie\LaravelMobilePass\Enums\Platform;
 use Spatie\LaravelMobilePass\Exceptions\CannotDownload;
 use Spatie\LaravelMobilePass\Exceptions\PlatformDoesntSupport;
 use Spatie\LaravelMobilePass\Jobs\PushPassUpdateJob;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
 use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassRegistration;
 use Spatie\LaravelMobilePass\Models\Google\GoogleMobilePassEvent;
 use Spatie\LaravelMobilePass\Support\Apple\DownloadableMobilePass;
@@ -78,6 +80,14 @@ class MobilePass extends Model implements Attachable, Responsable
         $modelClass = Config::appleMobilePassRegistrationModel();
 
         return $this->hasMany($modelClass, 'mobile_pass_id');
+    }
+
+    /** @return HasOne<AppleMobilePassPersonalization, $this> */
+    public function personalization(): HasOne
+    {
+        $modelClass = Config::appleMobilePassPersonalizationModel();
+
+        return $this->hasOne($modelClass, 'mobile_pass_id');
     }
 
     public function devices(): HasManyThrough

--- a/src/Support/Apple/PersonalizationTokenSigner.php
+++ b/src/Support/Apple/PersonalizationTokenSigner.php
@@ -12,25 +12,32 @@ class PersonalizationTokenSigner
         $tokenPath = tempnam(sys_get_temp_dir(), 'personalization-token');
         $signaturePath = tempnam(sys_get_temp_dir(), 'personalization-signature');
 
-        file_put_contents($tokenPath, $token);
+        try {
+            file_put_contents($tokenPath, $token);
 
-        [$cert, $privateKey] = $this->readCertificate();
+            [$cert, $privateKey] = $this->readCertificate();
 
-        openssl_pkcs7_sign(
-            $tokenPath,
-            $signaturePath,
-            $cert,
-            $privateKey,
-            [],
-            PKCS7_BINARY | PKCS7_DETACHED,
-        );
+            $signed = openssl_pkcs7_sign(
+                $tokenPath,
+                $signaturePath,
+                $cert,
+                $privateKey,
+                [],
+                PKCS7_BINARY | PKCS7_DETACHED,
+            );
 
-        $signature = file_get_contents($signaturePath);
+            if (! $signed) {
+                throw InvalidCertificate::fromPkcs7SignFailure();
+            }
 
-        unlink($tokenPath);
-        unlink($signaturePath);
+            $signature = file_get_contents($signaturePath);
 
-        return $this->convertPemToDer($signature);
+            return $this->convertPemToDer($signature);
+        } finally {
+            // Always clean up, whether signing succeeded or an exception was thrown above.
+            unlink($tokenPath);
+            unlink($signaturePath);
+        }
     }
 
     /** @return array{0: \OpenSSLCertificate|string, 1: \OpenSSLAsymmetricKey|string} */

--- a/src/Support/Apple/PersonalizationTokenSigner.php
+++ b/src/Support/Apple/PersonalizationTokenSigner.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelMobilePass\Support\Apple;
 
 use Spatie\LaravelMobilePass\Builders\Apple\ApplePassBuilder;
+use Spatie\LaravelMobilePass\Exceptions\InvalidCertificate;
 
 class PersonalizationTokenSigner
 {
@@ -40,7 +41,9 @@ class PersonalizationTokenSigner
 
         $p12Content = file_get_contents($certificatePath);
 
-        openssl_pkcs12_read($p12Content, $certs, $certificatePassword);
+        if (! openssl_pkcs12_read($p12Content, $certs, $certificatePassword)) {
+            throw InvalidCertificate::fromPkcs12ReadFailure();
+        }
 
         $cert = openssl_x509_read($certs['cert']);
         $privateKey = openssl_pkey_get_private($certs['pkey'], $certificatePassword);

--- a/src/Support/Apple/PersonalizationTokenSigner.php
+++ b/src/Support/Apple/PersonalizationTokenSigner.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Support\Apple;
+
+use Spatie\LaravelMobilePass\Builders\Apple\ApplePassBuilder;
+
+class PersonalizationTokenSigner
+{
+    public function sign(string $token): string
+    {
+        $tokenPath = tempnam(sys_get_temp_dir(), 'personalization-token');
+        $signaturePath = tempnam(sys_get_temp_dir(), 'personalization-signature');
+
+        file_put_contents($tokenPath, $token);
+
+        [$cert, $privateKey] = $this->readCertificate();
+
+        openssl_pkcs7_sign(
+            $tokenPath,
+            $signaturePath,
+            $cert,
+            $privateKey,
+            [],
+            PKCS7_BINARY | PKCS7_DETACHED,
+        );
+
+        $signature = file_get_contents($signaturePath);
+
+        unlink($tokenPath);
+        unlink($signaturePath);
+
+        return $this->convertPemToDer($signature);
+    }
+
+    /** @return array{0: \OpenSSLCertificate|string, 1: \OpenSSLAsymmetricKey|string} */
+    protected function readCertificate(): array
+    {
+        $certificatePath = ApplePassBuilder::getCertificatePath();
+        $certificatePassword = ApplePassBuilder::getCertificatePassword();
+
+        $p12Content = file_get_contents($certificatePath);
+
+        openssl_pkcs12_read($p12Content, $certs, $certificatePassword);
+
+        $cert = openssl_x509_read($certs['cert']);
+        $privateKey = openssl_pkey_get_private($certs['pkey'], $certificatePassword);
+
+        return [$cert, $privateKey];
+    }
+
+    protected function convertPemToDer(string $signature): string
+    {
+        $begin = 'filename="smime.p7s"';
+        $end = '------';
+
+        $signature = substr($signature, strpos($signature, $begin) + strlen($begin));
+        $signature = substr($signature, 0, strpos($signature, $end));
+        $signature = trim($signature);
+
+        return base64_decode($signature);
+    }
+}

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -96,7 +96,7 @@ class Config
      */
     public static function getActionClass(string $actionName, string $shouldBeOrExtend): string
     {
-        $actionClass = config("mobile-pass.actions.{$actionName}");
+        $actionClass = config("mobile-pass.actions.{$actionName}", $shouldBeOrExtend);
 
         if (! is_a($actionClass, $shouldBeOrExtend, true)) {
             throw InvalidConfig::invalidAction($actionName, $actionClass, $shouldBeOrExtend);

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -19,6 +19,7 @@ use Spatie\LaravelMobilePass\Builders\Google\OfferPassBuilder;
 use Spatie\LaravelMobilePass\Enums\Platform;
 use Spatie\LaravelMobilePass\Exceptions\InvalidConfig;
 use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassDevice;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
 use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassRegistration;
 use Spatie\LaravelMobilePass\Models\Google\GoogleMobilePassEvent;
 use Spatie\LaravelMobilePass\Models\MobilePass;
@@ -64,6 +65,12 @@ class Config
     public static function appleDeviceModel(): string
     {
         return self::getModelClass('apple_mobile_pass_device', AppleMobilePassDevice::class);
+    }
+
+    /** @return class-string<AppleMobilePassPersonalization> */
+    public static function appleMobilePassPersonalizationModel(): string
+    {
+        return self::getModelClass('apple_mobile_pass_personalization', AppleMobilePassPersonalization::class);
     }
 
     /** @return class-string<GoogleMobilePassEvent> */

--- a/tests/Builders/Apple/PersonalizationTest.php
+++ b/tests/Builders/Apple/PersonalizationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Personalization;
+use Spatie\LaravelMobilePass\Enums\PersonalizationField;
+use Spatie\LaravelMobilePass\Exceptions\InvalidConfig;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
+use Spatie\LaravelMobilePass\Builders\Apple\EventTicketPassBuilder;
+use Spatie\LaravelMobilePass\Support\Apple\PkPassReader;
+
+function personalizableBuilder(): EventTicketPassBuilder
+{
+    return EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Rewards')
+        ->setSerialNumber('BTL-REWARDS-0001')
+        ->setDescription('Beatles Rewards Card')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->setNfc(
+            message: 'REWARDS-0001',
+            encryptionPublicKey: 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE',
+        )
+        ->setPersonalization(Personalization::make(
+            description: 'Sign up to earn points.',
+            requiredPersonalizationFields: [PersonalizationField::Name, PersonalizationField::EmailAddress],
+        ))
+        ->setPersonalizationLogo(getTestSupportPath('images/spatie-thumbnail.png'));
+}
+
+it('throws when personalization is set without NFC', function () {
+    EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Rewards')
+        ->setSerialNumber('BTL-REWARDS-0002')
+        ->setDescription('Beatles Rewards Card')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->setPersonalization(Personalization::make(
+            description: 'Sign up to earn points.',
+            requiredPersonalizationFields: [PersonalizationField::Name],
+        ))
+        ->data();
+})->throws(InvalidConfig::class, 'NFC');
+
+it('persists the personalization config on save', function () {
+    $pass = personalizableBuilder()->save();
+
+    $this->assertDatabaseHas('apple_mobile_pass_personalizations', [
+        'mobile_pass_id' => $pass->getKey(),
+        'description' => 'Sign up to earn points.',
+    ]);
+
+    $personalization = AppleMobilePassPersonalization::where('mobile_pass_id', $pass->getKey())->first();
+    expect($personalization->required_fields)->toBe([
+        'PKPassPersonalizationFieldName',
+        'PKPassPersonalizationFieldEmailAddress',
+    ]);
+});
+
+it('bundles personalization.json and the logo while pending', function () {
+    $pass = personalizableBuilder()->save();
+
+    $reader = PkPassReader::fromString($pass->generate());
+
+    expect($reader->containsFile('personalization.json'))->toBeTrue();
+    expect($reader->containsFile('personalizationLogo.png'))->toBeTrue();
+
+    $personalizationJson = json_decode($reader->fileContent('personalization.json'), true);
+    expect($personalizationJson['description'])->toBe('Sign up to earn points.');
+});
+
+it('omits personalization.json and the logo once personalized', function () {
+    $pass = personalizableBuilder()->save();
+
+    AppleMobilePassPersonalization::where('mobile_pass_id', $pass->getKey())
+        ->update(['personalized_at' => now()]);
+
+    $reader = PkPassReader::fromString($pass->fresh()->generate());
+
+    expect($reader->containsFile('personalization.json'))->toBeFalse();
+    expect($reader->containsFile('personalizationLogo.png'))->toBeFalse();
+});

--- a/tests/Entities/PersonalizationTest.php
+++ b/tests/Entities/PersonalizationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Personalization;
+use Spatie\LaravelMobilePass\Enums\PersonalizationField;
+
+it('serializes description, required fields, and terms and conditions', function () {
+    $personalization = Personalization::make(
+        description: 'Enter your information to sign up and earn points.',
+        requiredPersonalizationFields: [
+            PersonalizationField::Name,
+            PersonalizationField::EmailAddress,
+        ],
+        termsAndConditions: 'Terms apply.',
+    );
+
+    expect($personalization->toArray())->toBe([
+        'requiredPersonalizationFields' => [
+            'PKPassPersonalizationFieldName',
+            'PKPassPersonalizationFieldEmailAddress',
+        ],
+        'description' => 'Enter your information to sign up and earn points.',
+        'termsAndConditions' => 'Terms apply.',
+    ]);
+});
+
+it('omits termsAndConditions when not set', function () {
+    $personalization = Personalization::make(
+        description: 'Sign up.',
+        requiredPersonalizationFields: [PersonalizationField::PostalCode],
+    );
+
+    expect($personalization->toArray())->toBe([
+        'requiredPersonalizationFields' => ['PKPassPersonalizationFieldPostalCode'],
+        'description' => 'Sign up.',
+    ]);
+});
+
+it('hydrates from an array', function () {
+    $personalization = Personalization::fromArray([
+        'description' => 'Sign up.',
+        'requiredPersonalizationFields' => ['PKPassPersonalizationFieldPhoneNumber'],
+        'termsAndConditions' => 'Terms apply.',
+    ]);
+
+    expect($personalization->description)->toBe('Sign up.');
+    expect($personalization->requiredPersonalizationFields)->toBe([PersonalizationField::PhoneNumber]);
+    expect($personalization->termsAndConditions)->toBe('Terms apply.');
+});

--- a/tests/Feature/PersonalizationFlowTest.php
+++ b/tests/Feature/PersonalizationFlowTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Tests\Feature;
+
+use Spatie\LaravelMobilePass\Builders\Apple\Entities\Personalization;
+use Spatie\LaravelMobilePass\Builders\Apple\EventTicketPassBuilder;
+use Spatie\LaravelMobilePass\Enums\PersonalizationField;
+use Spatie\LaravelMobilePass\Support\Apple\PkPassReader;
+
+it('bundles personalization.json until /personalize is called, then omits it', function () {
+    $pass = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Rewards')
+        ->setSerialNumber('BTL-REWARDS-9000')
+        ->setDescription('Beatles Rewards Card')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->setNfc(
+            message: 'REWARDS-9000',
+            encryptionPublicKey: 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE',
+        )
+        ->setPersonalization(Personalization::make(
+            description: 'Sign up to earn points.',
+            requiredPersonalizationFields: [PersonalizationField::Name],
+        ))
+        ->setPersonalizationLogo(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->save();
+
+    // Simulates the device downloading the pass in a fresh request — hydrate from DB only.
+    $downloadedBeforeSignup = PkPassReader::fromString($pass->fresh()->generate());
+    expect($downloadedBeforeSignup->containsFile('personalization.json'))->toBeTrue();
+
+    // Personalization must be driven entirely by the presence/absence of personalization.json —
+    // never by fields inside pass.json itself.
+    expect($downloadedBeforeSignup->passProperties())->not->toHaveKey('personalizationRequired');
+    expect($downloadedBeforeSignup->passProperties())->not->toHaveKey('personalizationToken');
+
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]), [
+            'personalizationToken' => 'wallet-issued-token',
+            'requiredPersonalizationInfo' => ['fullName' => 'John Appleseed'],
+        ])
+        ->assertSuccessful();
+
+    $downloadedAfterSignup = PkPassReader::fromString($pass->fresh()->generate());
+    expect($downloadedAfterSignup->containsFile('personalization.json'))->toBeFalse();
+    expect($downloadedAfterSignup->containsFile('personalizationLogo.png'))->toBeFalse();
+});
+
+it('serves the personalized pass via the existing check-for-updates endpoint', function () {
+    $pass = EventTicketPassBuilder::make()
+        ->setOrganizationName('Fab Four Rewards')
+        ->setSerialNumber('BTL-REWARDS-9001')
+        ->setDescription('Beatles Rewards Card')
+        ->setIconImage(getTestSupportPath('images/spatie-thumbnail.png'))
+        ->setNfc(
+            message: 'REWARDS-9001',
+            encryptionPublicKey: 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE',
+        )
+        ->setPersonalization(Personalization::make(
+            description: 'Sign up to earn points.',
+            requiredPersonalizationFields: [PersonalizationField::Name],
+        ))
+        ->save();
+
+    $beforeSignup = $pass->fresh()->updated_at;
+
+    $this->travel(1)->minutes();
+
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]), [
+            'personalizationToken' => 'wallet-issued-token',
+            'requiredPersonalizationInfo' => ['fullName' => 'John Appleseed'],
+        ]);
+
+    $response = $this
+        ->withoutMiddleware()
+        ->withHeaders(['If-Modified-Since' => $beforeSignup->toRfc7231String()])
+        ->getJson(route('mobile-pass.check-for-updates', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]));
+
+    $response->assertSuccessful();
+
+    // Prove that the normal Wallet update-check flow — not a special-cased response —
+    // is what delivers the personalized pass: read the real HTTP response body.
+    $reader = PkPassReader::fromString($response->getContent());
+    expect($reader->containsFile('personalization.json'))->toBeFalse();
+});

--- a/tests/Http/Controllers/PersonalizeControllerTest.php
+++ b/tests/Http/Controllers/PersonalizeControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Spatie\LaravelMobilePass\Tests\Http;
+
+use Illuminate\Support\Facades\Event;
+use Spatie\LaravelMobilePass\Events\PassPersonalized;
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+it('signs the submitted token and persists the submission', function () {
+    $pass = MobilePass::factory()->create();
+
+    AppleMobilePassPersonalization::factory()->create([
+        'mobile_pass_id' => $pass->getKey(),
+    ]);
+
+    $response = $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]), [
+            'personalizationToken' => '324389RFHF32JOID2902F3JF23092FEJI02',
+            'requiredPersonalizationInfo' => [
+                'fullName' => 'John Appleseed',
+                'emailAddress' => 'john.appleseed@icloud.com',
+            ],
+        ]);
+
+    $response->assertSuccessful();
+    $response->assertHeader('Content-Type', 'application/octet-stream');
+    expect($response->getContent())->not->toBeEmpty();
+
+    $this->assertDatabaseHas('apple_mobile_pass_personalizations', [
+        'mobile_pass_id' => $pass->getKey(),
+        'personalization_token' => '324389RFHF32JOID2902F3JF23092FEJI02',
+    ]);
+
+    $personalization = AppleMobilePassPersonalization::where('mobile_pass_id', $pass->getKey())->first();
+    expect($personalization->submitted_info)->toBe([
+        'fullName' => 'John Appleseed',
+        'emailAddress' => 'john.appleseed@icloud.com',
+    ]);
+    expect($personalization->personalized_at)->not->toBeNull();
+});
+
+it('touches the pass so check-for-updates serves a fresh pass afterward', function () {
+    $pass = MobilePass::factory()->create();
+    $originalUpdatedAt = $pass->updated_at;
+
+    AppleMobilePassPersonalization::factory()->create(['mobile_pass_id' => $pass->getKey()]);
+
+    $this->travel(1)->minutes();
+
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]), [
+            'personalizationToken' => 'some-token',
+            'requiredPersonalizationInfo' => ['fullName' => 'John Appleseed'],
+        ]);
+
+    expect($pass->fresh()->updated_at->gt($originalUpdatedAt))->toBeTrue();
+});
+
+it('fires PassPersonalized', function () {
+    Event::fake([PassPersonalized::class]);
+
+    $pass = MobilePass::factory()->create();
+    AppleMobilePassPersonalization::factory()->create(['mobile_pass_id' => $pass->getKey()]);
+
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]), [
+            'personalizationToken' => 'some-token',
+            'requiredPersonalizationInfo' => ['fullName' => 'John Appleseed'],
+        ]);
+
+    Event::assertDispatched(
+        fn (PassPersonalized $event) => $event->mobilePass->is($pass)
+            && $event->submittedInfo === ['fullName' => 'John Appleseed'],
+    );
+});
+
+it('returns 404 if the pass doesnt exist', function () {
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => 'does-not-exist',
+            'passTypeId' => 'pass.com.example',
+        ]), [
+            'personalizationToken' => 'some-token',
+            'requiredPersonalizationInfo' => ['fullName' => 'John Appleseed'],
+        ])
+        ->assertNotFound();
+});
+
+it('returns 422 when the payload is missing required keys', function () {
+    $pass = MobilePass::factory()->create();
+
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]), [])
+        ->assertUnprocessable();
+});

--- a/tests/Http/Controllers/PersonalizeControllerTest.php
+++ b/tests/Http/Controllers/PersonalizeControllerTest.php
@@ -111,3 +111,22 @@ it('returns 422 when the payload is missing required keys', function () {
         ]), [])
         ->assertUnprocessable();
 });
+
+it('returns 404 when the pass has no personalization config', function () {
+    $pass = MobilePass::factory()->create();
+
+    $this
+        ->withoutMiddleware()
+        ->postJson(route('mobile-pass.apple.personalize', [
+            'passSerial' => $pass->pass_serial,
+            'passTypeId' => 'pass.com.example',
+        ]), [
+            'personalizationToken' => 'some-token',
+            'requiredPersonalizationInfo' => ['fullName' => 'John Appleseed'],
+        ])
+        ->assertNotFound();
+
+    $this->assertDatabaseMissing('apple_mobile_pass_personalizations', [
+        'mobile_pass_id' => $pass->getKey(),
+    ]);
+});

--- a/tests/Models/AppleMobilePassPersonalizationTest.php
+++ b/tests/Models/AppleMobilePassPersonalizationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Spatie\LaravelMobilePass\Models\Apple\AppleMobilePassPersonalization;
+use Spatie\LaravelMobilePass\Models\MobilePass;
+
+it('belongs to a mobile pass', function () {
+    $pass = MobilePass::factory()->create();
+
+    $personalization = AppleMobilePassPersonalization::factory()->create([
+        'mobile_pass_id' => $pass->getKey(),
+    ]);
+
+    expect($personalization->pass->is($pass))->toBeTrue();
+    expect($pass->personalization->is($personalization))->toBeTrue();
+});
+
+it('casts required_fields and submitted_info as arrays and personalized_at as a datetime', function () {
+    $personalization = AppleMobilePassPersonalization::factory()->create([
+        'required_fields' => ['PKPassPersonalizationFieldName'],
+        'submitted_info' => ['fullName' => 'John Appleseed'],
+        'personalized_at' => now(),
+    ]);
+
+    expect($personalization->required_fields)->toBe(['PKPassPersonalizationFieldName']);
+    expect($personalization->submitted_info)->toBe(['fullName' => 'John Appleseed']);
+    expect($personalization->personalized_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+});

--- a/tests/Support/Apple/PersonalizationTokenSignerTest.php
+++ b/tests/Support/Apple/PersonalizationTokenSignerTest.php
@@ -1,6 +1,25 @@
 <?php
 
+use Spatie\LaravelMobilePass\Exceptions\InvalidCertificate;
 use Spatie\LaravelMobilePass\Support\Apple\PersonalizationTokenSigner;
+
+it('throws InvalidCertificate and cleans up temp files when the certificate cannot be loaded', function () {
+    config()->set('mobile-pass.apple.certificate_password', 'wrong-password');
+
+    $before = glob(sys_get_temp_dir().'/personalization-*');
+
+    try {
+        (new PersonalizationTokenSigner)->sign('some-token');
+
+        $this->fail('Expected InvalidCertificate to be thrown.');
+    } catch (InvalidCertificate $exception) {
+        // expected
+    }
+
+    $after = glob(sys_get_temp_dir().'/personalization-*');
+
+    expect($after)->toBe($before);
+});
 
 it('produces a non-empty binary signature over the token', function () {
     $signature = (new PersonalizationTokenSigner)->sign('324389RFHF32JOID2902F3JF23092FEJI02');

--- a/tests/Support/Apple/PersonalizationTokenSignerTest.php
+++ b/tests/Support/Apple/PersonalizationTokenSignerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Spatie\LaravelMobilePass\Support\Apple\PersonalizationTokenSigner;
+
+it('produces a non-empty binary signature over the token', function () {
+    $signature = (new PersonalizationTokenSigner)->sign('324389RFHF32JOID2902F3JF23092FEJI02');
+
+    expect($signature)->not->toBeEmpty();
+    expect($signature)->not->toBe('324389RFHF32JOID2902F3JF23092FEJI02');
+});
+
+it('produces different signatures for different tokens', function () {
+    $signer = new PersonalizationTokenSigner;
+
+    expect($signer->sign('token-a'))->not->toBe($signer->sign('token-b'));
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,6 +54,9 @@ class TestCase extends Orchestra
         $migration = include __DIR__.'/../database/migrations/add_locales_to_mobile_passes_table.php.stub';
         $migration->up();
 
+        $migration = include __DIR__.'/../database/migrations/create_apple_mobile_pass_personalizations_table.php.stub';
+        $migration->up();
+
         Schema::create('test_models', function (Blueprint $table) {
             $table->id();
             $table->timestamps();


### PR DESCRIPTION
## Summary

Adds support for Apple Wallet's **Rewards Enrollment** (pass personalization): NFC-enabled reward passes that prompt the user to sign up via a Wallet-native form on install, POST
the submitted info to a new web-service endpoint, and get replaced with a signed personalized pass.

Most of Apple's flow is served by infrastructure this package already had — the existing `CheckForUpdatesController` delivers the personalized pass once it's marked as such, and the existing logging endpoint handles Wallet's signature-verification warnings. The genuinely new surface is small: a `Personalization` entity, one new table, one new endpoint, and a signing utility.

## What's new

- **`Personalization` entity + `PersonalizationField` enum** — `description`, `requiredPersonalizationFields` (`Name` / `PostalCode` / `EmailAddress` / `PhoneNumber`), optional `termsAndConditions`.
- **`ApplePassBuilder::setPersonalization()` / `setPersonalizationLogo()`** — configures a pass as personalizable. Requires `setNfc()` (Apple restricts rewards enrollment to  NFC-enabled passes); the check is deferred to `data()` so setter call order doesn't matter.
- **`apple_mobile_pass_personalizations` table** — one row per personalizable pass, holding both the config (so it survives the separate HTTP request that later downloads the  pass) and the eventual submission (`personalization_token`, `submitted_info`, `personalized_at`).
- **Bundling logic** — `personalization.json` and the logo are bundled into the pass while pending, and omitted once personalized. No `pass.json` fields are added for this feature
  — there's no documented `personalizationRequired`/`personalizationToken` key, so the state lives entirely in the separate `personalization.json` file's presence or absence.
- **`POST /passkit/v1/passes/{passTypeId}/{passSerial}/personalize`** — signs whatever token Wallet sends (we never mint one ourselves), persists the submission, and touches the  pass so the *existing* check-for-updates endpoint naturally serves the personalized pass next.
- **`PassPersonalized` event** — fires after a successful submission, carrying the pass and the raw submitted info, so the host app can create the user's account (explicitly out  of this package's scope, per Apple's own guidance).
- **`PersonalizationTokenSigner`** — signs the token via the same `.p12` certificate already used for pass signing (PKCS#7 detached, matching the pattern in   `vendor/pkpass/pkpass`).                    

## Design notes worth knowing

- **Round-trip fix**: a pass download happens in a separate HTTP request from whichever request called `setPersonalization()` (`ApplePassBuilder::hydrate()` only reads            
  `content`/`images`/`locales`, never re-runs the fluent chain). So the `Personalization` config is persisted to the new table by `save()` and re-read by `uncompileContent()` on  every hydration — it can't just live in memory.
- **Sign before persist**: `PersonalizeAction` signs the token *before* writing `personalized_at`, so a signing failure never leaves a pass permanently stuck in "personalized"  state without a valid response ever reaching Wallet.
- **Push-notification isolation**: touching the pass triggers a synchronous APNs push (pre-existing behavior); a push failure is caught and reported, not allowed to turn an otherwise-successful `/personalize` response into a 500.

## Known open item

**Not verified against a real device**: whether Apple Wallet actually sends the `Authorization: ApplePass <secret>` header on the `/personalize` POST.   Worth a real-device test before relying on this in production.

## Test plan

- [x] Full test suite run locally (all passing)
- [x] Entity, builder, model, action/controller, and end-to-end integration tests added for every layer
- [x] Multi-round code review (per-task + whole-branch) with all Important/Critical findings fixed        
